### PR TITLE
Initial vcs-js integration

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "react-dom": "^15.1.0",
     "react-redux": "^4.4.5",
     "redux": "^3.5.2",
-    "redux-undo": "^0.6.1"
+    "redux-undo": "^0.6.1",
+    "vcs-js": "github:uv-cdat/vcs-js"
   },
   "devDependencies": {
     "babel-cli": "^6.4.0",
@@ -17,6 +18,7 @@
     "babel-loader": "^6.2.1",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
+    "json-loader": "^0.5.4",
     "webpack": "^1.12.11",
     "webpack-dev-server": "^1.14.1"
   },

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,3 +1,5 @@
+var path = require('path');
+
 module.exports = {
     entry: __dirname + "/src/js/App.js",
     devtool: 'inline-source-map',
@@ -20,6 +22,49 @@ module.exports = {
             query: {
                 presets: ['es2015', 'react']
             }
-        }]
+        }, {
+            test: /\.svg$/,
+            loader: 'svg-sprite',
+            exclude: /fonts/
+        }, {
+            test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+            loader: 'url-loader?limit=60000&mimetype=application/font-woff'
+        }, {
+            test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+            loader: 'url-loader?limit=60000',
+            include: /fonts/
+        }, {
+            test: /\.(png|jpg)$/,
+            loader: 'url-loader?limit=8192'
+        }, {
+            test: /\.css$/,
+            loader: 'style!css!postcss'
+        }, {
+            test: /\.c$/i,
+            loader: 'shader',
+        }, {
+            test: /\.glsl$/i,
+            loader: 'shader'
+        }, {
+            test: /\.json$/,
+            loader: 'json-loader'
+        }, {
+            test: /\.html$/,
+            loader: 'html-loader'
+        }, {
+            test: /\.js$/,
+            include: [
+              /node_modules\/paraviewweb/,
+              /node_modules\/vcs-js/
+            ],
+            loader: 'babel?presets[]=es2015',
+          }]
+    },
+    resolve: {
+        alias: {
+            vcs: path.resolve('./node_modules/vcs-js/src/index'),
+            ParaViewWeb: path.resolve('./node_modules/paraviewweb/src'),
+            plotly: path.resolve('./node_modules/plotly.js/dist/plotly')
+        }
     }
 };


### PR DESCRIPTION
This is by no means correct, good, or even working.  It is just a start at bringing vtkweb style sessions into the codebase.  A few notes about this:

* After running `npm install`, you need to run `./node_modules/.bin/fix-autobahn` to remove some node specific code that webpack doesn't handle.
* You need to have a vtkweb server running.  For that all you need is a vtk build (with `-D VTK_Group_Web=ON`), then run `vtkpython server.py` on server script found [here](https://github.com/UV-CDAT/vcs-js/blob/master/server/server.py).
* Some CSS/event binding magic needs to happen to size the plot window correctly.
* We need to handle unbinding the vtkweb viewer from its DOM element at the appropriate places in React's component lifecycle.