### PR TITLE
Removed old provenance code

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
 # This file may be used to create an environment using:
 # $ conda create --name <env> --file <this file>
 # platform: osx-64
-cdms2=2.8=Provenance
+cdms2=2.8
 vcs=2.8
 uvcdat=2.8.0
 vcs-js

--- a/backend/vcdat/app.py
+++ b/backend/vcdat/app.py
@@ -199,12 +199,11 @@ def load_variables_from_file():
 @app.route("/getVariableProvenance")
 @jsonresp
 def get_variable_provenance():
+    # We'll upgrade this to have real provenance at some point.
+    # For now, we're just doing straight reads.
     path = request.args.get('path')
     varname = request.args.get('varname')
-    f = cdms2.open(path)
-    v = f[varname]
-    ep = v.exportProvenance()
-    return json.dumps(ep)
+    return json.dumps({"uri": path, "variable": varname})
 
 
 if __name__ == "__main__":   # pragma: no cover


### PR DESCRIPTION
Removed the dependency on my old provenance code. Since we're putting the calculator on hold, we don't need to worry about getting all of the provenance stuff squared away, and instead will just open data provided by the user (via opendap, ESGF, or files).