### PR TITLE
Adds core-js polyfill

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "dependencies": {
     "bootstrap-slider": "github:matthewma7/bootstrap-slider",
+    "core-js": "^2.5.1",
     "css-element-queries": "^0.3.2",
     "jquery": "^3.1.0",
     "lodash": "^4.17.4",

--- a/frontend/src/js/App.js
+++ b/frontend/src/js/App.js
@@ -1,3 +1,4 @@
+import 'core-js';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import AppContainer from './containers/AppContainer.jsx';


### PR DESCRIPTION
VCS-js and vcdat are using some modern JavaScript API. 
[core-js](https://github.com/zloirock/core-js) is a very popular one-stop-shop for polyfill that I used before. 
Using the polyfill will at least make it usable with IE 11. (The one I tested with).

This PR may not be needed if we don't want to support IE.
