### PR TITLE
Fix colormap delete

### DIFF
--- a/frontend/src/js/components/modals/ColormapEditor/ColormapWidget.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/ColormapWidget.jsx
@@ -107,36 +107,37 @@ class ColormapWidget extends Component {
     handleDeleteColormap(){
         // TODO: If i use a colormap then delete it what happens?
         let nameToDelete = this.state.selectedColormapName
-        try{
-            if(vcs){ // eslint-disable-line no-undef
-                vcs.deleteColormap(nameToDelete).then((data)=>{console.log(data)}) // eslint-disable-line no-undef
+        if(nameToDelete !== "default"){
+            try{
+                if(vcs){ // eslint-disable-line no-undef
+                    vcs.deleteColormap(nameToDelete).then((data)=>{console.log(data)}) // eslint-disable-line no-undef
+                }
             }
-        }
-        catch(e){
-            if(e instanceof ReferenceError){
-                console.warn("VCS is not defined. Is the VCS Server running?")
+            catch(e){
+                if(e instanceof ReferenceError){
+                    console.warn("VCS is not defined. Is the VCS Server running?")
+                }
             }
+            let colormapNames = Object.keys(this.props.colormaps).sort(function (a, b) {
+                return a.toLowerCase().localeCompare(b.toLowerCase())
+            })
+            let index = colormapNames.indexOf(nameToDelete)
+            if(index == colormapNames.length - 1){ // if the colormap to delete is the last in the list
+                index = colormapNames.length - 2; // select the colormap before it
+            }
+            else{
+                index++ // else, select the colormap below it
+            }
+            let name = colormapNames[index]
+            let currentColormap = _.map(this.props.colormaps[name], _.clone())
+            this.props.deleteColormap(nameToDelete)
+            setTimeout(()=>{
+                this.setState({
+                    selectedColormapName: name,
+                    currentColormap: currentColormap,
+                })  
+            }, 0)
         }
-        let colormapNames = Object.keys(this.props.colormaps).sort(function (a, b) {
-            return a.toLowerCase().localeCompare(b.toLowerCase())
-        })
-        let index = colormapNames.indexOf(nameToDelete)
-        if(index == colormapNames.length - 1){ // if the colormap to delete is the last in the list
-            index = colormapNames.length - 2; // select the colormap before it
-        }
-        else{
-            index++ // else, select the colormap below it
-        }
-        let name = colormapNames[index]
-        let currentColormap = _.map(this.props.colormaps[name], _.clone())
-        this.props.deleteColormap(nameToDelete)
-        setTimeout(()=>{
-            this.setState({
-                selectedColormapName: name,
-                currentColormap: currentColormap,
-            })  
-        }, 0)
-        
     }
 
     blendColors(){

--- a/frontend/src/js/components/modals/ColormapEditor/ColormapWidget.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/ColormapWidget.jsx
@@ -105,7 +105,18 @@ class ColormapWidget extends Component {
     }
 
     handleDeleteColormap(){
+        // TODO: If i use a colormap then delete it what happens?
         let nameToDelete = this.state.selectedColormapName
+        try{
+            if(vcs){ // eslint-disable-line no-undef
+                vcs.deleteColormap(nameToDelete).then((data)=>{console.log(data)}) // eslint-disable-line no-undef
+            }
+        }
+        catch(e){
+            if(e instanceof ReferenceError){
+                console.warn("VCS is not defined. Is the VCS Server running?")
+            }
+        }
         let colormapNames = Object.keys(this.props.colormaps).sort(function (a, b) {
             return a.toLowerCase().localeCompare(b.toLowerCase())
         })
@@ -171,7 +182,7 @@ class ColormapWidget extends Component {
 
         /* eslint-disable no-undef */ 
         if(vcs){
-            vcs.colormapnames().then((names) => {
+            vcs.getcolormapnames().then((names) => {
                 if(names.indexOf(colormap_name) >= 0){
                     vcs.setcolormap(colormap_name, self.state.currentColormap).then(() => { // save colormap in vcs
                         self.props.saveColormap(colormap_name, self.state.currentColormap) // save to the frontend state

--- a/frontend/src/js/models/Colormaps.js
+++ b/frontend/src/js/models/Colormaps.js
@@ -21,7 +21,7 @@ class ColormapModel extends BaseModel {
             if(vcs){ // will throw an error if vcs server is not running/unreachable. This is caught as "ReferenceError" below
                 // This code is rather hard to read, but vcs.js does not provide a 'getallcolormaps' function 
                 return new Promise((resolve, reject) => { // Configure store expects an object, rather than an array, so we wrap a promise around promise.all
-                    vcs.colormapnames().then((names) => { 
+                    vcs.getcolormapnames().then((names) => { 
                         return Promise.all(names.map((name) => { // The array of colormaps starts as an array of promises. Use promise all to wait for all of them to finish
                             return vcs.getcolormap(name).then((map) => { // for each colormap name, create an object with the name and the colormap data
                                 return {name: name, colormap: map}

--- a/frontend/src/js/models/GraphicsMethods.js
+++ b/frontend/src/js/models/GraphicsMethods.js
@@ -5,11 +5,12 @@ import BaseModel from './BaseModel.js';
 class GraphicsMethodModel extends BaseModel {
 
     static reduce(state={}, action) {
+        let new_graphics_methods = {};
         switch (action.type) {
             case "INITIALIZE_GRAPHICS_METHODS_VALUES":
                 return action.graphics_methods;
             case "UPDATE_GRAPHICS_METHOD":
-                let new_graphics_methods = Object.assign({}, state)
+                new_graphics_methods = Object.assign({}, state)
                 const gm = action.graphics_method;
                 switch (gm.g_name) {
                     case "Gfb":
@@ -41,6 +42,16 @@ class GraphicsMethodModel extends BaseModel {
                         break;
                 }
                 return new_graphics_methods;
+            case "DELETE_COLORMAP":
+                new_graphics_methods = Object.assign({}, state)
+                for(let type of Object.keys(new_graphics_methods)){
+                    for(let name of Object.keys(new_graphics_methods[type])){
+                        if(action.name === new_graphics_methods[type][name].colormap){
+                            new_graphics_methods[type][name].colormap = "default"
+                        }
+                    }
+                }
+                return new_graphics_methods
             default:
                 return state
         }


### PR DESCRIPTION
Fixes the delete colormap button so that it removes the colormap from both the local state and the vcs server. In the event that a graphics method was using the deleted colormap it sets that graphics method back to the "default" colormap.