### PR TITLE
Cell select bug

### DIFF
--- a/frontend/src/js/components/Canvas.jsx
+++ b/frontend/src/js/components/Canvas.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import ResizeSensor from 'css-element-queries/src/ResizeSensor';
 import { connect } from 'react-redux';
-import PubSub from 'pubsub-js'
-import PubSubEvents from '../constants/PubSubEvents.js'
 import Actions from '../constants/Actions.js'
 import $ from 'jquery';
 import _ from 'lodash';
@@ -19,9 +17,24 @@ var Canvas = React.createClass({
         selected_cell_id: React.PropTypes.number,
         cell_id: React.PropTypes.number,
     },
+    shouldComponentUpdate(nextProps){
+        try{
+            // quick and dirty deep equality check
+            if(JSON.stringify(this.props) === JSON.stringify(nextProps)){
+                console.log("skipping a render")
+                return false
+            }
+        }
+        catch(e){
+            console.error(e)
+        }
+        console.log("doing a render")
+        console.log(JSON.stringify(this.props))
+        console.log(JSON.stringify(nextProps))
+        return true
+    },
     componentDidMount() {
         this.canvas = vcs.init(this.refs.div);
-        this.token = PubSub.subscribe(PubSubEvents.clear_canvas, this.clearCellAndCanvas)
     },
     componentDidUpdate(prevProps, prevState) {
         // Sync the size of the canvas
@@ -64,11 +77,8 @@ var Canvas = React.createClass({
     componentWillUnmount() {
         this.canvas.close();
     },
-    clearCellAndCanvas(){
-        if(this.props.cell_id == this.props.selected_cell_id){
-            this.props.clearCell(this.props.row, this.props.col) // removes plot state from redux
-            this.canvas.clear()
-        }
+    clearCanvas(){
+        this.canvas.clear()
     },
     render() {
         return (
@@ -102,17 +112,12 @@ const mapStateToProps = (state, ownProps) => {
     };
 
     return {
-        selected_cell_id: state.present.sheets_model.selected_cell_id,
         plotVariables: ownProps.plots.map(get_vars_for_plot),
         plotGMs: ownProps.plots.map(get_gm_for_plot),
     }
 }
 const mapDispatchToProps = (dispatch) => {
-    return {
-        clearCell: function(row, col){
-            dispatch(Actions.clearCell(row, col))
-        },
-    }
+    return {}
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Canvas);

--- a/frontend/src/js/components/Canvas.jsx
+++ b/frontend/src/js/components/Canvas.jsx
@@ -116,4 +116,4 @@ const mapDispatchToProps = (dispatch) => {
     return {}
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Canvas);
+export default connect(mapStateToProps, mapDispatchToProps, null, { withRef: true })(Canvas);

--- a/frontend/src/js/components/Canvas.jsx
+++ b/frontend/src/js/components/Canvas.jsx
@@ -21,16 +21,12 @@ var Canvas = React.createClass({
         try{
             // quick and dirty deep equality check
             if(JSON.stringify(this.props) === JSON.stringify(nextProps)){
-                console.log("skipping a render")
                 return false
             }
         }
         catch(e){
             console.error(e)
         }
-        console.log("doing a render")
-        console.log(JSON.stringify(this.props))
-        console.log(JSON.stringify(nextProps))
         return true
     },
     componentDidMount() {

--- a/frontend/src/js/components/Cell.jsx
+++ b/frontend/src/js/components/Cell.jsx
@@ -26,7 +26,7 @@ class Cell extends React.Component {
         }
     }
     componentDidMount(){
-        this.token = PubSub.subscribe(PubSubEvents.clear_canvas, this.clearCanvas) // todo: clean this up?
+        this.token = PubSub.subscribe(PubSubEvents.clear_canvas, this.clearCanvas.bind(this))
     }
     selectCell(){
         if(this.props.selected_cell_id == this.state.cell_id){
@@ -43,7 +43,7 @@ class Cell extends React.Component {
     }
     clearCanvas(){
         if(this.state.cell_id == this.props.selected_cell_id){
-            this.refs.canvas.clearCanvas()
+            this.refs.canvas.getWrappedInstance().clearCanvas()
             this.props.clearCell(this.props.row, this.props.col) // removes plot state from redux
         }
     }

--- a/frontend/src/js/components/Cell.jsx
+++ b/frontend/src/js/components/Cell.jsx
@@ -4,8 +4,9 @@ import Actions from '../constants/Actions.js';
 import Plotter from './Plotter.jsx';
 import Canvas from './Canvas.jsx';
 import {DropTarget} from 'react-dnd';
+import PubSub from 'pubsub-js'
+import PubSubEvents from '../constants/PubSubEvents.js'
 import DragAndDropTypes from '../constants/DragAndDropTypes.js';
-
 
 
 function collect(connect, monitor) {
@@ -17,27 +18,21 @@ function collect(connect, monitor) {
 
 const cellTarget = {};
 
-var Cell = React.createClass({
-    getInitialState() {
-        return { cell_id: undefined };
-    },
-    propTypes: {
-        cells: React.PropTypes.array,
-        row: React.PropTypes.number,
-        col: React.PropTypes.number,
-        addPlot: React.PropTypes.func,
-        swapVariableInPlot: React.PropTypes.func,
-        swapGraphicsMethodInPlot: React.PropTypes.func,
-        swapTemplateInPlot: React.PropTypes.func,
-        connectDropTarget: React.PropTypes.func,
-        isOver: React.PropTypes.bool,
-        selectCell: React.PropTypes.func,
-        deselectCell: React.PropTypes.func,
-        selected_cell_id: React.PropTypes.number,
-    },
+class Cell extends React.Component {
+    constructor(props){
+        super(props)
+        this.state = { 
+            cell_id: undefined 
+        }
+    }
+    componentDidMount(){
+        this.token = PubSub.subscribe(PubSubEvents.clear_canvas, this.clearCanvas) // todo: clean this up?
+    }
     selectCell(){
         if(this.props.selected_cell_id == this.state.cell_id){
-            this.props.deselectCell() // if a cell is selected, a user clicking on it should deselect it. 
+            // this.props.deselectCell() // if a cell is selected, a user clicking on it should deselect it.
+            // Turning this feature off since a user manipulating an interactive plot toggles the selection too much
+            return
         }
         else{
             let date = new Date()
@@ -45,7 +40,13 @@ var Cell = React.createClass({
             this.setState({cell_id: timestamp})
             this.props.selectCell(timestamp)
         }
-    },
+    }
+    clearCanvas(){
+        if(this.state.cell_id == this.props.selected_cell_id){
+            this.refs.canvas.clearCanvas()
+            this.props.clearCell(this.props.row, this.props.col) // removes plot state from redux
+        }
+    }
     render() {
         this.cell = this.props.cells[this.props.row][this.props.col];
         this.row = this.props.row;
@@ -63,11 +64,28 @@ var Cell = React.createClass({
                     swapGraphicsMethodInPlot={this.props.swapGraphicsMethodInPlot}
                     swapTemplateInPlot={this.props.swapTemplateInPlot}
                 />
-                <Canvas onTop={!this.props.isOver} plots={this.cell.plots} row={this.props.row} col={this.props.col} cell_id={this.state.cell_id} selected_cell_id={this.props.selected_cell_id}/>}
+                <Canvas ref="canvas" onTop={!this.props.isOver} plots={this.cell.plots} row={this.props.row} col={this.props.col} />}
             </div>
         );
     }
-});
+}
+
+Cell.propTypes = {
+    cells: React.PropTypes.array,
+    row: React.PropTypes.number,
+    col: React.PropTypes.number,
+    addPlot: React.PropTypes.func,
+    swapVariableInPlot: React.PropTypes.func,
+    swapGraphicsMethodInPlot: React.PropTypes.func,
+    swapTemplateInPlot: React.PropTypes.func,
+    connectDropTarget: React.PropTypes.func,
+    isOver: React.PropTypes.bool,
+    selectCell: React.PropTypes.func,
+    deselectCell: React.PropTypes.func,
+    selected_cell_id: React.PropTypes.number,
+    clearCell: React.PropTypes.func,
+}
+
 const mapStateToProps = (state) => {
     return {
         cells: state.present.sheets_model.sheets[state.present.sheets_model.cur_sheet_index].cells,
@@ -93,7 +111,10 @@ const mapDispatchToProps = (dispatch) => {
         },
         deselectCell: function(){
             dispatch(Actions.deselectCell())
-        }
+        },
+        clearCell: function(row, col){
+            dispatch(Actions.clearCell(row, col))
+        },
     }
 }
 


### PR DESCRIPTION
The cell select feature added a new prop to be handed to the Canvas element. Each time a user clicked the cell, the prop would be updated and the canvas would re-render. This resulted in 3d plots losing interactivity since user actions would be instantly negated by rendering a new 3d plot. 

Cell selection is now handled properly by the Cell component, and the Canvas element now implements the shouldComponentUpdate lifecycle hook in order to prevent unnecessary re-renders. 