### PR TITLE
Fixes nightly builds by removing uvcdat requirement

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,8 +4,8 @@
 
 cdms2
 vcs
-uvcdat
 vcs-js
 nodejs
 flask
 service_identity
+vcsaddons

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CONDA_ENV=${CONDA_ENV:-nightly}
+CONDA_ENV=${CONDA_ENV:-test_setup}
 
 CERT=$1
 if [ "-"$CERT"-" == "-auto-" ]; then
@@ -47,7 +47,7 @@ if [[ $current_dir == */vcdat* ]]; then
     conda env remove -y -n ${CONDA_ENV}
 
     # Create a new one
-    conda create -y -n ${CONDA_ENV} uvcdat -c uvcdat/label/nightly -c conda-forge -c uvcdat --file $current_dir/backend/requirements.txt
+    conda create -y -n ${CONDA_ENV} -c uvcdat/label/nightly -c conda-forge -c uvcdat --file $current_dir/backend/requirements.txt
 
     source activate ${CONDA_ENV}
     cd frontend


### PR DESCRIPTION
Having uvcdat as a requirement prevented conda from using the nightly vcs build. Removed uvcdat as a requirement since it was overkill and added vcsaddons since uvcdat is no longer including it for us. 