### PR TITLE
Resize on col row

### DIFF
--- a/frontend/deps/Styles.css
+++ b/frontend/deps/Styles.css
@@ -181,6 +181,9 @@ button:focus {
 .cell-selected{
     border: 1px solid blue;
 }
+.canvas-container{
+    overflow: hidden;
+}
 .plotter {
     display:flex;
     color: black;

--- a/frontend/src/js/components/Canvas.jsx
+++ b/frontend/src/js/components/Canvas.jsx
@@ -38,7 +38,6 @@ var Canvas = React.createClass({
         var canvas = div.find("canvas");
         canvas.attr("width", div.width());
         canvas.attr("height", div.height());
-        this.canvas.clear()
         if (this.props.plots !== prevProps.plots) {
             this.props.plots.map((plot, index) => {
                 if (plot.variables.length > 0) {
@@ -78,7 +77,7 @@ var Canvas = React.createClass({
     },
     render() {
         return (
-            <div className={this.props.onTop ? "cell-stack-top" : "cell-stack-bottom"} ref="div"></div>
+            <div className={this.props.onTop ? "cell-stack-top canvas-container" : "cell-stack-bottom canvas-container"} ref="div"></div>
         )
     }
 });

--- a/frontend/src/js/components/Canvas.jsx
+++ b/frontend/src/js/components/Canvas.jsx
@@ -64,12 +64,15 @@ var Canvas = React.createClass({
             }
         });
     },
+    /* istanbul ignore next */
     componentWillUnmount() {
         this.canvas.close();
     },
+    /* istanbul ignore next */
     clearCanvas(){
         this.canvas.clear()
     },
+    /* istanbul ignore next */
     resizeCanvas(){
         this.canvas.close()
         delete this.canvas
@@ -84,14 +87,7 @@ var Canvas = React.createClass({
 });
 
 const mapStateToProps = (state, ownProps) => {
-    var can_plot = ownProps.plots.reduce((prevVal, curVal) => {
-        if (prevVal === false) {
-            return prevVal;
-        }
-        return curVal.variables.length > 0;
-    }, true);
-
-    if (!can_plot) {
+    if (!ownProps.can_plot) {
         return {
             plotVariables: [],
         }

--- a/frontend/src/js/components/Cell.jsx
+++ b/frontend/src/js/components/Cell.jsx
@@ -47,24 +47,43 @@ class Cell extends React.Component {
             this.props.clearCell(this.props.row, this.props.col) // removes plot state from redux
         }
     }
+    canPlot(cell){
+        if(cell.plots){
+            return cell.plots.reduce((prevVal, curVal) => {
+                if (prevVal === false) {
+                    return prevVal;
+                }
+                return curVal.variables.length > 0;
+            }, true);
+        }
+        return false
+    }
     render() {
         this.cell = this.props.cells[this.props.row][this.props.col];
-        this.row = this.props.row;
-        this.col = this.props.col;
         this.class = this.state.cell_id == this.props.selected_cell_id ? 'cell cell-selected' : 'cell'
+        this.can_plot = this.canPlot(this.cell)
+        this.plotter_on_top = this.props.isOver || !this.can_plot
         return this.props.connectDropTarget(
             <div className={this.class} data-row={this.props.row} data-col={this.props.col} onClick={() => {this.selectCell()}}>
                 <Plotter
-                    onTop={this.props.isOver}
+                    onTop={this.plotter_on_top}
                     cell={this.cell}
                     row={this.props.row}
                     col={this.props.col}
+                    can_plot={this.can_plot}
                     addPlot={this.props.addPlot}
                     swapVariableInPlot={this.props.swapVariableInPlot}
                     swapGraphicsMethodInPlot={this.props.swapGraphicsMethodInPlot}
                     swapTemplateInPlot={this.props.swapTemplateInPlot}
                 />
-                <Canvas ref="canvas" onTop={!this.props.isOver} plots={this.cell.plots} row={this.props.row} col={this.props.col} />}
+                <Canvas 
+                    ref="canvas"
+                    onTop={!this.plotter_on_top}
+                    plots={this.cell.plots}
+                    row={this.props.row}
+                    col={this.props.col}
+                    can_plot={this.can_plot}
+                />
             </div>
         );
     }

--- a/frontend/src/js/components/Plot.jsx
+++ b/frontend/src/js/components/Plot.jsx
@@ -17,6 +17,20 @@ const plotTarget = {
                 props.swapTemplateInPlot(item.template, props.plotIndex);
                 break;
         }
+        component.setState({highlight: undefined})
+    },
+    hover(props, monitor, component){
+        switch (monitor.getItemType()) {
+            case DragAndDropTypes.GM:
+                component.setState({highlight: "graphics_method"})
+                break;
+            case DragAndDropTypes.VAR:
+                component.setState({highlight: "variables"})
+                break;
+            case DragAndDropTypes.TMPL:
+                component.setState({highlight: "template"})
+                break;
+        }
     }
 }; 
 
@@ -37,7 +51,7 @@ var Plot = React.createClass({
         swapGraphicsMethodInPlot: React.PropTypes.func,
         swapTemplateInPlot: React.PropTypes.func,
         connectDropTarget: React.PropTypes.func,
-
+        isOver: React.PropTypes.bool,
     },
     validSecondVar(event, ui) {
         if (ui.draggable.attr('data-type') === 'variable' && this.props.plot.graphics_method_parent === 'vector') {
@@ -55,7 +69,7 @@ var Plot = React.createClass({
         return this.props.connectDropTarget(
             <div className='plot' id={this.props.plotName} data-plot-index={this.props.plotIndex}>
                 <div>
-                    <h4>Variables:</h4>
+                    <h4 style={{color: this.props.isOver && this.state.highlight=="variables"? 'lime' : ''}}>Variables:</h4>
                     <div className='plot-var first-var'>{(this.props.plot.variables.length > 0
                             ? this.props.plot.variables[0].cdms_var_name
                             : '')}
@@ -69,12 +83,12 @@ var Plot = React.createClass({
                     </div>
                 </div>
                 <div>
-                    <h4>Graphics method:</h4>
+                    <h4 style={{color: this.props.isOver && this.state.highlight=="graphics_method"? 'lime' : ''}}>Graphics method:</h4>
                     <h5>{this.props.plot.graphics_method_parent}</h5>
                     <h5>{this.props.plot.graphics_method}</h5>
                 </div>
                 <div>
-                    <h4>Template:</h4>
+                    <h4 style={{color: this.props.isOver && this.state.highlight=="template"? 'lime' : ''}}>Template:</h4>
                     <h5>{this.props.plot.template}</h5>
                 </div>
             </div>

--- a/frontend/src/js/constants/PubSubEvents.js
+++ b/frontend/src/js/constants/PubSubEvents.js
@@ -1,4 +1,5 @@
 var pub_sub_events = {
     clear_canvas: "canvas.clear",
+    resize: "canvas.resize",
 }
 export default pub_sub_events

--- a/frontend/src/js/containers/SpreadsheetContainer/SpreadsheetContainer.jsx
+++ b/frontend/src/js/containers/SpreadsheetContainer/SpreadsheetContainer.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { Modal, ButtonToolbar, Button, Row, Col, Glyphicon, FormGroup, FormControl, ControlLabel, InputGroup } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 
 import Cell from 'components/Cell.jsx';
 import { connect } from 'react-redux';
 import Actions from 'constants/Actions.js';
 import Spinner from 'components/Spinner/Spinner.jsx';
+import PubSub from 'pubsub-js'
+import PubSubEvents from '../../constants/PubSubEvents.js'
 import './SpreadsheetContainer.scss';
 /* global $ */
 
@@ -185,9 +187,11 @@ var SpreadsheetContainer = React.createClass({
         // $('#spreadsheet-div').selectable({filter: '.cell', stop: this.updateSelectedCells});
         this.initDragAndDrop();
     },
-    componentDidUpdate() {
+    componentDidUpdate(prevProps) {
         this.initDragAndDrop();
-
+        if(prevProps.cur_sheet.row_count != this.props.cur_sheet.row_count || prevProps.cur_sheet.col_count != this.props.cur_sheet.col_count){
+            PubSub.publish(PubSubEvents.resize)
+        }
     },
     dropppedColHeader(event, ui) {
         var dragged_index = ui.draggable.attr('data-col');


### PR DESCRIPTION
Provides a method to work around resizing plots. We have to destroy each canvas, reinitialize, then re-plot each one. It is expensive, but functional.

Also fixed the plot overlay so it stays open when there isnt a plot to show, and made the text highlight when dragging. (The switch used to indicate that you could drop, but since that is static we needed some sort of indicator)
