### PR TITLE
Colormap editor refactor

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -18,7 +18,14 @@
     ],
     "rules": {
             "max-len": ["error", 150, 4],
-            "spaced-comment": ["error", "always"]
+            "spaced-comment": ["error", "always"],
+            "no-console": ["error", { 
+                "allow": ["warn", "error"]
+            }]
+    },
+    "globals": {
+        "vcs": true
     },
     "root": true
+
 }

--- a/frontend/src/js/components/Canvas.jsx
+++ b/frontend/src/js/components/Canvas.jsx
@@ -35,7 +35,8 @@ class Canvas extends Component{
     componentDidMount() {
         try{
             this.canvas = vcs.init(this.refs.div);
-            this.token = PubSub.subscribe(PubSubEvents.resize, this.resetCanvas.bind(this))
+            this.resize_token = PubSub.subscribe(PubSubEvents.resize, this.resetCanvas.bind(this))
+            this.colormap_token = PubSub.subscribe(PubSubEvents.colormap_update, this.handleColormapUpdate.bind(this))
         }
         catch(e){
             if(e instanceof ReferenceError && e.message == "vcs is not defined"){
@@ -135,6 +136,19 @@ class Canvas extends Component{
         delete this.canvas
         this.canvas = vcs.init(this.refs.div);
         this.forceUpdate()
+    }
+
+    handleColormapUpdate(msg, name){
+        let needs_render = false
+        for(let plot of this.props.plotGMs){
+            if(plot.colormap === name){
+                needs_render = true
+                break
+            }
+        }
+        if(needs_render){
+            this.forceUpdate()
+        }
     }
 
     render() {

--- a/frontend/src/js/components/PlotTools/PlotTools.jsx
+++ b/frontend/src/js/components/PlotTools/PlotTools.jsx
@@ -61,7 +61,9 @@ class PlotTools extends Component{
                         <i className='glyphicon glyphicon-share-alt'></i>
                     </button>
                 </div>
-                <ColormapEditor show={this.state.showColormapEditor} close={() => this.setState({showColormapEditor: false})}/>
+                {this.state.showColormapEditor && 
+                    <ColormapEditor show={this.state.showColormapEditor} close={() => this.setState({showColormapEditor: false})}/>
+                }
             </div>
         )
     }

--- a/frontend/src/js/components/modals/ColormapEditor/ColormapEditor.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/ColormapEditor.jsx
@@ -16,7 +16,6 @@ class ColormapEditor extends Component {
             currentColor: colorUtility.toState("#333"),
             showImportExportModal: false,
             selectedColormapName: "viridis",
-            select_val: "viridis",
             show_new_colormap_modal: false,
         }
     }
@@ -50,12 +49,8 @@ class ColormapEditor extends Component {
     }
 
     handleSelectColormap(name){
-        this.setState({select_val: name})
-    }
-
-    handleLoadColormap(){
-        this.setState({selectedColormapName: this.state.select_val})
-        this.refs.widget.getWrappedInstance().handleColormapSelect(this.state.select_val)
+        this.setState({selectedColormapName: name})
+        this.refs.widget.getWrappedInstance().handleColormapSelect(name)
     }
 
     handleOpenNewColormapModal(){
@@ -66,7 +61,7 @@ class ColormapEditor extends Component {
 
     handleDeleteColormap(){
         // TODO: If i use a colormap then delete it what happens?
-        let nameToDelete = this.state.select_val
+        let nameToDelete = this.state.selectedColormapName
         if(nameToDelete !== "default"){
             if(confirm(`Are you sure you want to delete '${nameToDelete}'?`)) {
                 try{
@@ -102,7 +97,6 @@ class ColormapEditor extends Component {
                 toast.success("Colormap deleted successfully", { position: toast.POSITION.BOTTOM_CENTER })
                 setTimeout(()=>{
                     this.setState({
-                        select_val: name,
                         selectedColormapName: name,
                         currentColormap: currentColormap,
                     })
@@ -118,16 +112,16 @@ class ColormapEditor extends Component {
         }
     }
 
-    createNewColormap(name){
-        if(Object.keys(this.props.colormaps).indexOf(name) >= 0){
+    createNewColormap(new_cm_name){
+        if(Object.keys(this.props.colormaps).indexOf(new_cm_name) >= 0){
             toast.warn("A colormap with that name already exists. Please select a different name", {position: toast.POSITION.BOTTOM_CENTER})
         }
         else{
-            this.refs.widget.getWrappedInstance().createNewColormap(this.state.select_val, name).then((result)=>{
+            this.refs.widget.getWrappedInstance().createNewColormap(this.state.selectedColormapName, new_cm_name).then((result)=>{
                 if(result){
-                    this.refs.widget.getWrappedInstance().handleColormapSelect(name)
+                    this.refs.widget.getWrappedInstance().handleColormapSelect(new_cm_name)
                     this.setState({
-                        selectedColormapName: name,
+                        selectedColormapName: new_cm_name,
                         show_new_colormap_modal: false,
                     })
                     toast.success("Colormap created successfully", {position: toast.POSITION.BOTTOM_CENTER})
@@ -157,7 +151,7 @@ class ColormapEditor extends Component {
                                     className="form-control"
                                     style={{marginLeft: "5px", marginRight: "5px"}}
                                     onChange={(event) => {this.handleSelectColormap(event.target.value)}}
-                                    value={this.state.select_val}>
+                                    value={this.state.selectedColormapName}>
                                     { this.props.colormaps ? (
                                         Object.keys(this.props.colormaps).sort(function (a, b) {
                                             return a.toLowerCase().localeCompare(b.toLowerCase());
@@ -168,13 +162,6 @@ class ColormapEditor extends Component {
                                 </select>
                             </div>
                             <div>
-                                <button 
-                                    title="Load the selected colormap for editing"
-                                    onClick={() => {this.handleLoadColormap()}}
-                                    className="btn btn-default btn-sm"
-                                    style={{marginLeft: "5px"}}>
-                                        Load
-                                </button>
                                 <button 
                                     title="Create a new copy of the selected colormap"
                                     onClick={() => {this.handleOpenNewColormapModal()}}

--- a/frontend/src/js/components/modals/ColormapEditor/ColormapEditor.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/ColormapEditor.jsx
@@ -126,16 +126,15 @@ class ColormapEditor extends Component {
                     index++ // else, select the colormap below it
                 }
                 let name = colormapNames[index]
-                let current_colormap = _.map(this.props.colormaps[name], _.clone())
                 this.props.deleteColormap(nameToDelete)
                 toast.success("Colormap deleted successfully", { position: toast.POSITION.BOTTOM_CENTER })
-                setTimeout(()=>{
-                    this.setState({
-                        selected_colormap_name: name,
-                        current_colormap: current_colormap,
-                    })
-                    this.handleSelectColormap(name)
-                }, 0)
+                let current_colormap = _.map(this.props.colormaps[name], _.clone())
+                this.setState({
+                    selected_colormap_name: name,
+                    current_colormap: current_colormap,
+                    selected_cells_start: -1,
+                    selected_cells_end: -1,
+                })
             } 
             else{
                 return
@@ -338,7 +337,7 @@ class ColormapEditor extends Component {
                                 <label htmlFor="cm-select" className="control-label">Colormaps</label>
                                 <select
                                     name="cm-select"
-                                    className="form-control"
+                                    className="form-control example"
                                     style={{marginLeft: "5px", marginRight: "5px"}}
                                     onChange={(event) => {this.handleSelectColormap(event.target.value)}}
                                     value={this.state.selected_colormap_name}>

--- a/frontend/src/js/components/modals/ColormapEditor/ColormapEditor.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/ColormapEditor.jsx
@@ -36,7 +36,7 @@ class ColormapEditor extends Component {
             selected_cell_row: React.PropTypes.number,
             colormaps: React.PropTypes.object,
             default_colormap: React.PropTypes.string,
-            delete_colormap: React.PropTypes.func,
+            deleteColormap: React.PropTypes.func,
             saveColormap: React.PropTypes.func,
         }; 
     }
@@ -85,6 +85,11 @@ class ColormapEditor extends Component {
         this.setState({
             selected_cells_start: start_cell,
             selected_cells_end: end_cell,
+        }, () => {
+            const r = this.state.current_colormap[this.state.selected_cells_end][0] * 2.55
+            const g = this.state.current_colormap[this.state.selected_cells_end][1] * 2.55
+            const b = this.state.current_colormap[this.state.selected_cells_end][2] * 2.55
+            this.handleChange(colorUtility.toState(`rgb(${r},${g},${b})`))
         })
     }
 
@@ -94,8 +99,8 @@ class ColormapEditor extends Component {
         if(nameToDelete !== "default"){
             if(confirm(`Are you sure you want to delete '${nameToDelete}'?`)) {
                 try{
-                    if(vcs){ // eslint-disable-line no-undef
-                        vcs.removecolormap(nameToDelete).catch((e) => {throw e}) // eslint-disable-line no-undef
+                    if(vcs){
+                        vcs.removecolormap(nameToDelete).catch((e) => {throw e})
                     }
                 }
                 catch(e){
@@ -122,7 +127,7 @@ class ColormapEditor extends Component {
                 }
                 let name = colormapNames[index]
                 let current_colormap = _.map(this.props.colormaps[name], _.clone())
-                this.props.delete_colormap(nameToDelete)
+                this.props.deleteColormap(nameToDelete)
                 toast.success("Colormap deleted successfully", { position: toast.POSITION.BOTTOM_CENTER })
                 setTimeout(()=>{
                     this.setState({
@@ -189,10 +194,13 @@ class ColormapEditor extends Component {
         }
     }
 
-    handleApplyColormap(colormap_name, cell_row, cell_col){
-        let self = this
-        let graphics_method_parent = self.props.sheet.cells[cell_row][cell_col].plots[0].graphics_method_parent
-        let graphics_method = self.props.sheet.cells[cell_row][cell_col].plots[0].graphics_method
+    handleApplyColormap(){
+        const colormap_name = this.state.selected_colormap_name
+        const cell_row = this.props.selected_cell_row
+        const cell_col = this.props.selected_cell_col
+        const self = this
+        const graphics_method_parent = self.props.sheet.cells[cell_row][cell_col].plots[0].graphics_method_parent
+        const graphics_method = self.props.sheet.cells[cell_row][cell_col].plots[0].graphics_method
 
         function applyColormapHelper(){
             try{
@@ -376,7 +384,7 @@ class ColormapEditor extends Component {
                     <Modal.Footer>
                         <Button 
                             style={{float: "left"}}
-                            onClick={() => {this.refs.widget.getWrappedInstance().blendColors()}}>
+                            onClick={() => {this.blendColors()}}>
                             Blend
                         </Button>
                         <Button 
@@ -395,7 +403,7 @@ class ColormapEditor extends Component {
                             onClick={() => {this.handleApplyColormap()}}>
                             Apply
                         </Button>
-                        <Button onClick={() => {this.refs.widget.getWrappedInstance().saveColormap(this.state.selected_colormap_name)}}>Save</Button>
+                        <Button onClick={() => {this.saveColormap(this.state.selected_colormap_name)}}>Save</Button>
                         <Button onClick={this.openImportExportModal.bind(this)}>Import/Export</Button>
                         <Button onClick={this.props.close}>Close</Button>
                     </Modal.Footer>
@@ -407,7 +415,7 @@ class ColormapEditor extends Component {
                 />
                 <ImportExportModal
                     show={this.state.show_import_export_modal}
-                    close={this.closeImportExportModal}
+                    close={()=>{this.closeImportExportModal()}}
                     current_colormap={this.state.current_colormap}
                     saveColormap={(name, cm) => this.saveColormap(name, cm)}
                 />
@@ -458,8 +466,8 @@ const mapDispatchToProps = (dispatch) => {
         updateGraphicsMethod: (graphics_method) => {
             dispatch(Actions.updateGraphicsMethod(graphics_method))
         },
-        delete_colormap: (name) => {
-            dispatch(Actions.delete_colormap(name));
+        deleteColormap: (name) => {
+            dispatch(Actions.deleteColormap(name));
         },
     }
 }

--- a/frontend/src/js/components/modals/ColormapEditor/ColormapEditor.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/ColormapEditor.jsx
@@ -287,7 +287,7 @@ class ColormapEditor extends Component {
                             Reset
                         </Button>
                         {apply}
-                        <Button onClick={() => {this.refs.widget.getWrappedInstance().saveColormap()}}>Save</Button>
+                        <Button onClick={() => {this.refs.widget.getWrappedInstance().saveColormap(this.state.selectedColormapName)}}>Save</Button>
                         <Button onClick={this.openImportExportModal.bind(this)}>Import/Export</Button>
                         <Button onClick={this.props.close}>Close</Button>
                     </Modal.Footer>

--- a/frontend/src/js/components/modals/ColormapEditor/ColormapWidget.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/ColormapWidget.jsx
@@ -30,7 +30,6 @@ class ColormapWidget extends Component {
             color: React.PropTypes.object,// the current colorpicker color 
             onChange: React.PropTypes.func,
             saveColormap: React.PropTypes.func,
-            deleteColormap: React.PropTypes.func,
             showImportExportModal: React.PropTypes.bool,
             closeImportExportModal: React.PropTypes.func,
             sheet: React.PropTypes.object,
@@ -139,7 +138,7 @@ class ColormapWidget extends Component {
     saveColormap(name){
         if(name){
             try{
-                vcs.setcolormap(name, this.state.currentColormap).then(() => {
+                return vcs.setcolormap(name, this.state.currentColormap).then(() => {
                     this.props.saveColormap(name, this.state.currentColormap)
                     toast.success("Save Successful", { position: toast.POSITION.BOTTOM_CENTER });
                     PubSub.publish(PubSubEvents.colormap_update, name)
@@ -157,10 +156,12 @@ class ColormapWidget extends Component {
             catch(e){
                 console.warn(e)
                 toast.error("Failed to save colormap", { position: toast.POSITION.BOTTOM_CENTER });
+                return Promise.reject()
             }
         }
         else{ // should not be possible, but just in case
             toast.error("Please enter a name to save this colormap", { position: toast.POSITION.BOTTOM_CENTER });
+            return Promise.reject()
         }
     }
 
@@ -323,9 +324,6 @@ const mapDispatchToProps = dispatch => {
             }
             return false
             
-        },
-        deleteColormap: (name) => {
-            dispatch(Actions.deleteColormap(name));
         },
         applyColormap: (graphics_method_parent, graphics_method, row, col, plot_index) =>{
             dispatch(Actions.swapGraphicsMethodInPlot(graphics_method_parent, graphics_method, row, col, plot_index));

--- a/frontend/src/js/components/modals/ColormapEditor/ColormapWidget.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/ColormapWidget.jsx
@@ -137,18 +137,29 @@ class ColormapWidget extends Component {
         
     }
 
-    saveColormap(){
-        if(this.state.newColormapTemplateName){
-            let result = this.props.saveColormap(this.state.newColormapTemplateName, this.state.currentColormap)
-            if(result){
-                // todo: add a vcs call here to save the colormap to the server
-                toast.success("Save Successful", { position: toast.POSITION.BOTTOM_CENTER });
+    saveColormap(name){
+        if(name){
+            try{
+                vcs.setcolormap(name, this.state.currentColormap).then(() => {
+                    this.props.saveColormap(name, this.state.currentColormap)
+                    toast.success("Save Successful", { position: toast.POSITION.BOTTOM_CENTER });
+                },
+                (error) => {
+                    console.warn(error)
+                    try{
+                        toast.error(error.data.exception, {position: toast.POSITION.BOTTOM_CENTER})
+                    }
+                    catch(e){
+                        toast.error("Failed to save colormap", { position: toast.POSITION.BOTTOM_CENTER });        
+                    }
+                })
             }
-            else{
+            catch(e){
+                console.warn(e)
                 toast.error("Failed to save colormap", { position: toast.POSITION.BOTTOM_CENTER });
             }
-        } 
-        else{
+        }
+        else{ // should not be possible, but just in case
             toast.error("Please enter a name to save this colormap", { position: toast.POSITION.BOTTOM_CENTER });
         }
     }

--- a/frontend/src/js/components/modals/ColormapEditor/ColormapWidget.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/ColormapWidget.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import './ColormapWidget.css'
-var colorUtility = require('react-color/lib/helpers/color.js').default;
 
 class ColormapWidget extends Component {
     constructor(props){
@@ -25,25 +24,21 @@ class ColormapWidget extends Component {
             }
             if(event.shiftKey){
                 if(this.props.selected_cells_start === -1){
-                    this.props.handleCellClick(0, index, r, g, b)
+                    this.props.handleCellClick(0, index)
                 }
                 else{
-                    this.props.handleCellClick(this.props.selected_cells_start, index, r, g, b)
+                    this.props.handleCellClick(this.props.selected_cells_start, index)
                 }
             }
             else{
                 if(this.props.selected_cells_start === this.props.selected_cells_end && this.props.selected_cells_start === index){
                     // if a single cell is selected and the user clicks it. Deselect the cell
-                    this.props.handleCellClick(-1, -1, r, g, b)
+                    this.props.handleCellClick(-1, -1)
                 }
                 else{
-                    this.props.handleCellClick(index, index, r, g, b)
+                    this.props.handleCellClick(index, index)
                 }   
             }
-            const r = this.props.current_colormap[index][0] * 2.55
-            const g = this.props.current_colormap[index][1] * 2.55
-            const b = this.props.current_colormap[index][2] * 2.55
-            // this.handleChange(colorUtility.toState(`rgb(${r},${g},${b})`))
         }
     }
 

--- a/frontend/src/js/components/modals/ColormapEditor/ColormapWidget.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/ColormapWidget.jsx
@@ -19,7 +19,6 @@ class ColormapWidget extends Component {
             selectedColormapName: this.props.defaultColormap, // a string, such as 'viridis', or 'AMIP'
             shouldUseProps: false, // value to indicate if color should be applied from props to color map
             showExportModal: false,
-            cm_name_input_class: "form-control cm-name-input"
         }
     }
 
@@ -106,74 +105,18 @@ class ColormapWidget extends Component {
         }
     }
 
-    handleSaveColormap(){
+    saveColormap(){
         if(this.state.newColormapTemplateName){ 
             let result = this.props.saveColormap(this.state.newColormapTemplateName, this.state.currentColormap)
             if(result){
                 toast.success("Save Successful", { position: toast.POSITION.BOTTOM_CENTER });
-                this.setState({cm_name_input_class: "form-control cm-name-input save-success"})
             }
             else{
                 toast.error("Failed to save colormap", { position: toast.POSITION.BOTTOM_CENTER });
-                this.setState({cm_name_input_class: "form-control cm-name-input save-fail"})
             }
         } 
         else{
             toast.error("Please enter a name to save this colormap", { position: toast.POSITION.BOTTOM_CENTER });
-            this.setState({cm_name_input_class: "form-control cm-name-input save-fail"})
-        }
-        setTimeout(function(){this.setState({cm_name_input_class: "form-control cm-name-input"})}.bind(this), 900)
-    }
-
-    handleDeleteColormap(){
-        // TODO: If i use a colormap then delete it what happens?
-        let nameToDelete = this.state.selectedColormapName
-        if(nameToDelete !== "default"){
-            if(confirm(`Are you sure you want to delete '${nameToDelete}'?`)) {
-                try{
-                    if(vcs){ // eslint-disable-line no-undef
-                        vcs.deleteColormap(nameToDelete).then((data)=>{console.log(data)}) // eslint-disable-line no-undef
-                    }
-                }
-                catch(e){
-                    if(e instanceof ReferenceError){
-                        console.warn("VCS is not defined. Is the VCS Server running?")
-                        toast.error("VCS is not loaded. Try restarting vCDAT", { position: toast.POSITION.BOTTOM_CENTER })
-                        return
-                    }
-                    else{
-                        console.warn(e)
-                        toast.error("Failed to delete colormap", { position: toast.POSITION.BOTTOM_CENTER })
-                        return
-                    }
-                }
-                let colormapNames = Object.keys(this.props.colormaps).sort(function (a, b) {
-                    return a.toLowerCase().localeCompare(b.toLowerCase())
-                })
-                let index = colormapNames.indexOf(nameToDelete)
-                if(index == colormapNames.length - 1){ // if the colormap to delete is the last in the list
-                    index = colormapNames.length - 2; // select the colormap before it
-                }
-                else{
-                    index++ // else, select the colormap below it
-                }
-                let name = colormapNames[index]
-                let currentColormap = _.map(this.props.colormaps[name], _.clone())
-                this.props.deleteColormap(nameToDelete)
-                toast.success("Colormap deleted successfully", { position: toast.POSITION.BOTTOM_CENTER })
-                setTimeout(()=>{
-                    this.setState({
-                        selectedColormapName: name,
-                        currentColormap: currentColormap,
-                    })  
-                }, 0)   
-            } 
-            else{
-                return
-            }
-        }
-        else{
-            toast.warn("The default colormap cannot be deleted", { position: toast.POSITION.BOTTOM_CENTER })
         }
     }
 
@@ -269,41 +212,6 @@ class ColormapWidget extends Component {
     render(){
         return(
             <div>
-                <div className="form-inline" style={{display: "flex", marginTop: "20px", marginBottom: "10px"}}>
-                    <button 
-                        title="Delete Selected Colormap"
-                        onClick={() => {this.handleDeleteColormap()}}
-                        className="btn btn-danger btn-sm"
-                        style={{marginRight: "5px"}}>
-                        <i className="glyphicon glyphicon-trash"></i>
-                    </button>
-                    <select 
-                        className="form-control"
-                        style={{marginRight: "5px"}}
-                        onChange={(event) => {this.handleColormapSelect(event.target.value)}}
-                        value={this.state.selectedColormapName}>
-                        { this.props.colormaps ? (
-                            Object.keys(this.props.colormaps).sort(function (a, b) {
-                                return a.toLowerCase().localeCompare(b.toLowerCase());
-                            }).map( name => ( <option key={name} value={name}>{name}</option> ))
-                            ) : (
-                            <option value="" disabled />
-                        )}
-                    </select>
-                    <input
-                        className={this.state.cm_name_input_class}
-                        style={{flexGrow: 1}} 
-                        value={this.state.newColormapTemplateName}
-                        onChange={(event) => { this.setState({newColormapTemplateName: event.target.value}) }}>
-                    </input>
-                    <button 
-                        className="form-control save-button"
-                        style={{marginLeft: "5px"}}
-                        onClick={() => {
-                            this.handleSaveColormap()
-                        }}>Save as...
-                    </button>
-                </div>
                 <span style={{fontSize: 11, fontWeight: 300}}title="*Shift+Click to select multiple cells">*Shift+Click to select multiple cells</span>
                 <div id="colormap-cells-container">
                 { (this.state.currentColormap) ? 

--- a/frontend/src/js/components/modals/ColormapEditor/ColormapWidget.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/ColormapWidget.jsx
@@ -1,94 +1,49 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux'
-import _ from 'lodash'
-import Actions from '../../../constants/Actions.js'
-import PubSub from 'pubsub-js'
-import PubSubEvents from '../../../constants/PubSubEvents.js'
-var colorUtility = require('react-color/lib/helpers/color.js').default
-import ImportExportModal from "./ImportExportModal.jsx";
-import { toast } from 'react-toastify'
 import './ColormapWidget.css'
+var colorUtility = require('react-color/lib/helpers/color.js').default;
 
 class ColormapWidget extends Component {
     constructor(props){
         super(props)
-        this.state = {
-            selectedCellsStart: -1,
-            selectedCellsEnd: -1,
-            currentColormap: this.props.colormaps[this.props.defaultColormap].map(function(arr) {
-                return arr.slice()
-            }), // an array of arrays representing the current cells 
-            selectedColormapName: this.props.defaultColormap, // a string, such as 'viridis', or 'AMIP'
-            showExportModal: false,
-        }
     }
 
-    static get propTypes() { 
-        return { 
-            colormaps: React.PropTypes.object, // object containing all colormaps. 
-            defaultColormap: React.PropTypes.string, // The name of the colormap to select when opening the editor
+    static get propTypes() {
+        return {
+            current_colormap: React.PropTypes.array,
             color: React.PropTypes.object,// the current colorpicker color 
-            onChange: React.PropTypes.func,
-            saveColormap: React.PropTypes.func,
-            showImportExportModal: React.PropTypes.bool,
-            closeImportExportModal: React.PropTypes.func,
-            sheet: React.PropTypes.object,
-            applyColormap: React.PropTypes.func,
-            graphics_methods: React.PropTypes.object,
-        }; 
-    }
-
-    componentWillReceiveProps(nextProps){
-        if(this.state.currentColormap && this.state.selectedCellsStart !== -1 && this.state.selectedCellsEnd !== -1){
-            let updatedColormap = this.state.currentColormap.slice()
-            updatedColormap[this.state.selectedCellsEnd][0] = Math.round((nextProps.color.rgb.r / 255) * 100)
-            updatedColormap[this.state.selectedCellsEnd][1] = Math.round((nextProps.color.rgb.g / 255) * 100)
-            updatedColormap[this.state.selectedCellsEnd][2] = Math.round((nextProps.color.rgb.b / 255) * 100)
-            this.setState({currentColormap: updatedColormap})
+            selected_cells_start: React.PropTypes.number,
+            selected_cells_end: React.PropTypes.number,
+            handleCellClick: React.PropTypes.func,
         }
-    }
-
-    handleColormapSelect(name){
-        let currentColormap = _.map(this.props.colormaps[name], _.clone())
-        this.setState({
-            selectedColormapName: name,
-            currentColormap: currentColormap,
-            selectedCellsStart: -1,
-            selectedCellsEnd: -1,
-        })
     }
 
     handleCellClick(event){
         if(event.target.innerText){
-            let index = Number.parseInt(event.target.innerText)
+            const index = Number.parseInt(event.target.innerText)
             if(isNaN(index)){
-                return 
+                return
             }
             if(event.shiftKey){
-                if(this.state.selectedCellsStart === -1){
-                    this.setState({
-                        selectedCellsStart: 0,
-                        selectedCellsEnd: index
-                    })
+                if(this.props.selected_cells_start === -1){
+                    this.props.handleCellClick(0, index, r, g, b)
                 }
                 else{
-                    this.setState({selectedCellsEnd: index})
+                    this.props.handleCellClick(this.props.selected_cells_start, index, r, g, b)
                 }
             }
             else{
-                if(this.state.selectedCellsStart === this.state.selectedCellsEnd && this.state.selectedCellsStart === index){
+                if(this.props.selected_cells_start === this.props.selected_cells_end && this.props.selected_cells_start === index){
                     // if a single cell is selected and the user clicks it. Deselect the cell
-                    this.setState({selectedCellsEnd: -1, selectedCellsStart: -1})
+                    this.props.handleCellClick(-1, -1, r, g, b)
                 }
                 else{
-                    this.setState({selectedCellsEnd: index, selectedCellsStart: index})
-                }
-                
+                    this.props.handleCellClick(index, index, r, g, b)
+                }   
             }
-            let r = this.state.currentColormap[index][0] * 2.55
-            let g = this.state.currentColormap[index][1] * 2.55
-            let b = this.state.currentColormap[index][2] * 2.55
-            this.props.onChange(colorUtility.toState(`rgb(${r},${g},${b})`))
+            const r = this.props.current_colormap[index][0] * 2.55
+            const g = this.props.current_colormap[index][1] * 2.55
+            const b = this.props.current_colormap[index][2] * 2.55
+            // this.handleChange(colorUtility.toState(`rgb(${r},${g},${b})`))
         }
     }
 
@@ -100,176 +55,19 @@ class ColormapWidget extends Component {
         return false
     }
 
-    resetColormap(){
-        if(this.state.selectedColormapName){
-            this.handleColormapSelect(this.state.selectedColormapName)
-        }
-    }
-
-    createNewColormap(base_cm, name){
-        // create should copy the current colormap, save it into vcs, 
-        // add it to redux and set it as active in the widget, and close the modal
-        // cancel should close the modal
-        try{
-            /* eslint-disable no-undef */ 
-            return vcs.createcolormap(name, base_cm).then((result)=>{
-                this.props.saveColormap(name, result)
-                return true
-            },
-            (error)=>{
-                try{
-                    toast.error(error.data.exception, {position: toast.POSITION.BOTTOM_CENTER})
-                }
-                catch(e){
-                    toast.error("Failed to create colormap", {position: toast.POSITION.BOTTOM_CENTER})
-                }
-                console.warn(error)
-                return false
-            })
-        }
-        catch(e){
-            console.warn(e)
-            toast.error("Failed to create colormap", {position: toast.POSITION.BOTTOM_CENTER})
-        }
-        return Promise.resolve(false)
-        
-    }
-
-    saveColormap(name){
-        if(name){
-            try{
-                return vcs.setcolormap(name, this.state.currentColormap).then(() => {
-                    this.props.saveColormap(name, this.state.currentColormap)
-                    toast.success("Save Successful", { position: toast.POSITION.BOTTOM_CENTER });
-                    PubSub.publish(PubSubEvents.colormap_update, name)
-                },
-                (error) => {
-                    console.warn(error)
-                    try{
-                        toast.error(error.data.exception, {position: toast.POSITION.BOTTOM_CENTER})
-                    }
-                    catch(e){
-                        toast.error("Failed to save colormap", { position: toast.POSITION.BOTTOM_CENTER });        
-                    }
-                })
-            }
-            catch(e){
-                console.warn(e)
-                toast.error("Failed to save colormap", { position: toast.POSITION.BOTTOM_CENTER });
-                return Promise.reject()
-            }
-        }
-        else{ // should not be possible, but just in case
-            toast.error("Please enter a name to save this colormap", { position: toast.POSITION.BOTTOM_CENTER });
-            return Promise.reject()
-        }
-    }
-
-    blendColors(){
-        let startCell = Math.min(this.state.selectedCellsStart, this.state.selectedCellsEnd)
-        let endCell = Math.max(this.state.selectedCellsStart, this.state.selectedCellsEnd)
-        let numCells = Math.abs(this.state.selectedCellsStart - this.state.selectedCellsEnd) - 1
-        if(numCells < 1 || this.state.selectedCellsStart === -1 || this.state.selectedCellsEnd === -1){
-            // numCells represents the number of cells in between the start and end cells.
-            // so selecting 2 cells gives numCells a value of 0.
-            toast.info("Not enough cells selected to blend. Shift + click to select more.", {
-                position: toast.POSITION.BOTTOM_CENTER
-              });
-            return
-        }
-        let startColor = this.state.currentColormap[startCell] // rgba array
-        let endColor = this.state.currentColormap[endCell] // rgba array
-        let redStep = (endColor[0] - startColor[0]) / (numCells+1)
-        let greenStep = (endColor[1] - startColor[1]) / (numCells+1)
-        let blueStep = (endColor[2] - startColor[2]) / (numCells+1)
-        let currentCell = startCell + 1
-        let blendedColormap = this.state.currentColormap.map(function(arr) {
-            return arr.slice(); // copy inner array of colors
-        });
-        
-        for(let count = 1; currentCell < endCell; currentCell++, count++){
-            blendedColormap[currentCell][0] = startColor[0] + (redStep * count)
-            blendedColormap[currentCell][1] = startColor[1] + (greenStep * count)
-            blendedColormap[currentCell][2] = startColor[2] + (blueStep * count)
-        }
-        this.setState({currentColormap: blendedColormap})
-    }
-
-    applyColormap(colormap_name, cell_row, cell_col){
-        let self = this
-        let graphics_method_parent = self.props.sheet.cells[cell_row][cell_col].plots[0].graphics_method_parent
-        let graphics_method = self.props.sheet.cells[cell_row][cell_col].plots[0].graphics_method
-
-        function applyColormapHelper(){
-            try{
-                let new_graphics_method = _.clone(self.props.graphics_methods[graphics_method_parent][graphics_method])
-                const prev_colormap = new_graphics_method.colormap
-                new_graphics_method.colormap = colormap_name
-                self.props.updateGraphicsMethod(new_graphics_method)
-                let plot = self.props.sheet.cells[cell_row][cell_col].plots[0]
-                self.props.applyColormap(plot.graphics_method_parent, graphics_method, cell_row, cell_col, 0)
-                if(prev_colormap === colormap_name){ // if the colormap has changed but the name hasnt, the canvas will not render
-                    PubSub.publish(PubSubEvents.colormap_update, colormap_name)
-                }
-                return true
-            }
-            catch(e){
-                return false
-            }
-            
-        }
-        return new Promise((resolve, reject) => {
-            try{
-                /* eslint-disable no-undef */ 
-                if(vcs){
-                    vcs.getcolormapnames().then((names) => {
-                        if(names.indexOf(colormap_name) >= 0){
-                            vcs.setcolormap(colormap_name, self.state.currentColormap).then(() => { // save colormap in vcs
-                                self.props.saveColormap(colormap_name, self.state.currentColormap) // save to the frontend state
-                                if(applyColormapHelper()){
-                                    resolve()
-                                }
-                                else{
-                                    reject()
-                                }
-                            })
-                        }
-                        else{
-                            vcs.createcolormap(colormap_name).then(() => {
-                                vcs.setcolormap(colormap_name, self.state.currentColormap).then(() => {
-                                    self.props.saveColormap(colormap_name, self.state.currentColormap) // save to the frontend state
-                                    if(applyColormapHelper()){
-                                        resolve()
-                                    }
-                                    else{
-                                        reject()
-                                    }
-                                })
-                            })
-                        }
-                    })
-                }
-                /* eslint-enable no-undef */
-            }
-            catch(e){
-                reject(e)
-            }
-        })
-    }
-
     render(){
         return(
             <div>
                 <span style={{fontSize: 11, fontWeight: 300}}title="*Shift+Click to select multiple cells">*Shift+Click to select multiple cells</span>
                 <div id="colormap-cells-container">
-                { (this.state.currentColormap) ? 
+                { (this.props.current_colormap) ? 
                     (
-                        this.state.currentColormap.map( (cell, index) => (
+                        this.props.current_colormap.map( (cell, index) => (
                         <div
                             className="cells"
                             key={`${index}${cell[0]}${cell[1]}${cell[2]}${cell[3]}`} // need a key that changes when the color does and is unique
                             style={{
-                                border:(this.cellActive(index, this.state.selectedCellsStart, this.state.selectedCellsEnd)) ? 
+                                border:(this.cellActive(index, this.props.selected_cells_start, this.props.selected_cells_end)) ? 
                                         "2px solid black" : "2px solid lightgrey",
                                 background: `rgb(${Math.round(cell[0]*2.55)}, ${Math.round(cell[1]*2.55)}, ${Math.round(cell[2]*2.55)}`,
                                 color: ((cell[0]*0.299 + cell[1]*0.587 + cell[2]*0.114)*2.55 > 186) ? ("#000000") : ("#ffffff"),
@@ -284,12 +82,6 @@ class ColormapWidget extends Component {
                         <span></span>
                     )}
                 </div>
-                <ImportExportModal
-                    show={this.props.showImportExportModal}
-                    close={this.props.closeImportExportModal}
-                    currentColormap={this.state.currentColormap}
-                    saveColormap={this.props.saveColormap}
-                />
             </div>
         )
     }
@@ -299,40 +91,4 @@ ColormapWidget.defaultProps = {
     defaultColormap: 'viridis'
 }
 
-const mapStateToProps = (state) => {
-    return {
-        colormaps: state.present.colormaps,
-        sheet: state.present.sheets_model.sheets[state.present.sheets_model.cur_sheet_index],
-        graphics_methods: state.present.graphics_methods,
-    }
-}
-
-const mapDispatchToProps = dispatch => {
-    return {
-        saveColormap: (name, colormap) => {
-            if(name){
-                let cm = {};
-                cm[name] = colormap;
-                try{
-                    dispatch(Actions.saveColormap(cm));
-                    return true
-                }
-                catch(e){
-                    console.error(e)
-                    return false
-                }
-            }
-            return false
-            
-        },
-        applyColormap: (graphics_method_parent, graphics_method, row, col, plot_index) =>{
-            dispatch(Actions.swapGraphicsMethodInPlot(graphics_method_parent, graphics_method, row, col, plot_index));
-        },
-        updateGraphicsMethod: (graphics_method) => {
-            dispatch(Actions.updateGraphicsMethod(graphics_method))
-        },
-    }
-}
-
-export default connect(mapStateToProps, mapDispatchToProps, null, { withRef: true })(ColormapWidget)
-export {ColormapWidget as PureColormapWidget}
+export default ColormapWidget

--- a/frontend/src/js/components/modals/ColormapEditor/ColormapWidget.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/ColormapWidget.jsx
@@ -31,9 +31,6 @@ class ColormapWidget extends Component {
             deleteColormap: React.PropTypes.func,
             showImportExportModal: React.PropTypes.bool,
             closeImportExportModal: React.PropTypes.func,
-            cur_sheet_index: React.PropTypes.number,
-            sheet_num_rows: React.PropTypes.number,
-            sheet_num_cols: React.PropTypes.number,
             sheet: React.PropTypes.object,
             applyColormap: React.PropTypes.func,
             graphics_methods: React.PropTypes.object,
@@ -194,11 +191,10 @@ class ColormapWidget extends Component {
         this.setState({currentColormap: blendedColormap})
     }
 
-    applyColormap(cell_row, cell_col){
+    applyColormap(colormap_name, cell_row, cell_col){
         let self = this
         let graphics_method_parent = self.props.sheet.cells[cell_row][cell_col].plots[0].graphics_method_parent
         let graphics_method = self.props.sheet.cells[cell_row][cell_col].plots[0].graphics_method
-        let colormap_name = "applied_colormap"
 
         function applyColormapHelper(){
             try{
@@ -298,9 +294,6 @@ ColormapWidget.defaultProps = {
 const mapStateToProps = (state) => {
     return {
         colormaps: state.present.colormaps,
-        cur_sheet_index: state.present.sheets_model.cur_sheet_index,
-        sheet_num_rows: state.present.sheets_model.sheets[state.present.sheets_model.cur_sheet_index].row_count,
-        sheet_num_cols: state.present.sheets_model.sheets[state.present.sheets_model.cur_sheet_index].col_count,
         sheet: state.present.sheets_model.sheets[state.present.sheets_model.cur_sheet_index],
         graphics_methods: state.present.graphics_methods,
     }

--- a/frontend/src/js/components/modals/ColormapEditor/ImportExportModal.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/ImportExportModal.jsx
@@ -17,7 +17,7 @@ class ImportExportModal extends Component {
         return { 
             show: React.PropTypes.bool.isRequired, // show the modal
             close: React.PropTypes.func.isRequired, // close the modal
-            currentColormap: React.PropTypes.array,
+            current_colormap: React.PropTypes.array,
             saveColormap: React.PropTypes.func,
         }; 
     }
@@ -25,7 +25,7 @@ class ImportExportModal extends Component {
     handleChange(e) {
         let colormap = {
             name: e.target.value,
-            colormap: this.props.currentColormap,
+            colormap: this.props.current_colormap,
         }
         let data = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(colormap));
         this.setState({

--- a/frontend/src/js/components/modals/ColormapEditor/NewColormapModal.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/NewColormapModal.jsx
@@ -1,0 +1,49 @@
+import React, { Component } from 'react'
+import { Modal, Button, FormGroup, FormControl, ControlLabel } from 'react-bootstrap';
+
+class NewColormapModal extends Component{
+    constructor(props){
+        super(props)
+        this.state = {
+            name: "",
+        }
+    }
+    
+    render(){
+        return(
+            <Modal show={this.props.show}>
+                <Modal.Header>
+                    <Modal.Title>Create Colormap</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <FormGroup>
+                        <ControlLabel>Name</ControlLabel>
+                        <FormControl
+                            autoFocus
+                            type="text"
+                            value={this.state.name}
+                            onChange={(e) => this.setState({ name: e.target.value })} />
+                    </FormGroup>
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button 
+                        bsStyle="primary"
+                        bsSize="small"
+                        onClick={() => {this.props.newColormap(this.state.name)
+                        }}>Create</Button>
+                    <Button 
+                        bsSize="small"
+                        onClick={() => this.props.close()}>Cancel</Button>
+                </Modal.Footer>
+            </Modal>
+        )
+    }
+}
+
+NewColormapModal.propTypes = {
+    show: React.PropTypes.bool,
+    close: React.PropTypes.func,
+    newColormap: React.PropTypes.func,
+}
+
+export default NewColormapModal

--- a/frontend/src/js/components/modals/ColormapEditor/NewColormapModal.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/NewColormapModal.jsx
@@ -17,23 +17,26 @@ class NewColormapModal extends Component{
                 </Modal.Header>
                 <Modal.Body>
                     <FormGroup>
-                        <ControlLabel>Name</ControlLabel>
-                        <FormControl
+                        <label
+                            htmlFor="name-input"
+                            className="control-label">Name</label>
+                        <input
                             autoFocus
                             type="text"
+                            className="form-control name-input"
+                            name="name-input"
                             value={this.state.name}
                             onChange={(e) => this.setState({ name: e.target.value })} />
                     </FormGroup>
                 </Modal.Body>
                 <Modal.Footer>
-                    <Button 
-                        bsStyle="primary"
-                        bsSize="small"
+                    <button
+                        className="btn btn-primary create"
                         onClick={() => {this.props.newColormap(this.state.name)
-                        }}>Create</Button>
-                    <Button 
-                        bsSize="small"
-                        onClick={() => this.props.close()}>Cancel</Button>
+                        }}>Create</button>
+                    <button
+                        className="btn btn-default cancel"
+                        onClick={() => this.props.close()}>Cancel</button>
                 </Modal.Footer>
             </Modal>
         )

--- a/frontend/src/js/constants/PubSubEvents.js
+++ b/frontend/src/js/constants/PubSubEvents.js
@@ -1,5 +1,6 @@
 var pub_sub_events = {
     clear_canvas: "canvas.clear",
     resize: "canvas.resize",
+    colormap_update: "colormap.update"
 }
 export default pub_sub_events

--- a/frontend/test/mocha/components/Modals/ColormapEditor/ColormapEditorTest.jsx
+++ b/frontend/test/mocha/components/Modals/ColormapEditor/ColormapEditorTest.jsx
@@ -65,41 +65,41 @@ describe('ColormapEditorTest.jsx', function() {
     //     expect(colormap_widget.state().currentColormap[2][0]).to.equal(100) // third cell red should be 100
     // });
     
-    // it('deletes a colormap properly', () => {
-    //     var state = { 
-    //         present: {
-    //             sheets_model: {
-    //                 sheets: [
-    //                     {row_count: 1, col_count: 1}
-    //                 ],
-    //                 selected_cell_id: "0_0_0",
-    //                 cur_sheet_index: 0
-    //             }
-    //         }
-    //     }
-    //     const store = createMockStore(state)
-    //     const colormap_editor = mount(<ColormapEditor store={store}/>)
-    //     let clock = sinon.useFakeTimers() // replace setTimout with a fake version that can be manipulated/ran synchronously
-    //     let warn = console.warn
-    //     console.warn = function(){return} // disable console.warn to prevent unnecessary warnings about vcs being missing
-    //     const confirm = sinon.stub(global, 'confirm')
-    //     confirm.returns(true)
-    //     global.vcs = {
-    //         deleteColormap() {
-    //             return Promise.resolve()
-    //         }
-    //     }
-    //     colormap_editor.instance().handleSelectColormap("testSelect")
-    //     colormap_editor.instance().handleDeleteColormap("testSelect")
-    //     clock.runAll() // force all setTimeout calls to process
-    //     expect(colormap_editor.state().selectedColormapName).to.equal("viridis") // since it is the only colormap left, viridis should be selected
-    //     for(let cell = 0; cell < 3; cell++){
-    //         for(let color_index = 0; color_index < 3; color_index++){
-    //             expect(colormap_editor.state().currentColormap[cell][color_index]).to.equal(props.colormaps.viridis[cell][color_index])
-    //         }
-    //     }
-    //     clock.restore()
-    //     console.warn = warn // restore console.warn
-    //     confirm.restore()
-    // });
+    it('deletes a colormap properly', () => {
+        var state = { 
+            present: {
+                sheets_model: {
+                    sheets: [
+                        {row_count: 1, col_count: 1}
+                    ],
+                    selected_cell_id: "0_0_0",
+                    cur_sheet_index: 0
+                }
+            }
+        }
+        const store = createMockStore(state)
+        const colormap_editor = mount(<ColormapEditor store={store}/>)
+        let clock = sinon.useFakeTimers() // replace setTimout with a fake version that can be manipulated/ran synchronously
+        let warn = console.warn
+        console.warn = function(){return} // disable console.warn to prevent unnecessary warnings about vcs being missing
+        const confirm = sinon.stub(global, 'confirm')
+        confirm.returns(true)
+        global.vcs = {
+            deleteColormap() {
+                return Promise.resolve()
+            }
+        }
+        colormap_editor.instance().handleSelectColormap("testSelect")
+        colormap_editor.instance().handleDeleteColormap("testSelect")
+        clock.runAll() // force all setTimeout calls to process
+        expect(colormap_editor.state().selectedColormapName).to.equal("viridis") // since it is the only colormap left, viridis should be selected
+        for(let cell = 0; cell < 3; cell++){
+            for(let color_index = 0; color_index < 3; color_index++){
+                expect(colormap_editor.state().currentColormap[cell][color_index]).to.equal(props.colormaps.viridis[cell][color_index])
+            }
+        }
+        clock.restore()
+        console.warn = warn // restore console.warn
+        confirm.restore()
+    });
 });

--- a/frontend/test/mocha/components/Modals/ColormapEditor/ColormapEditorTest.jsx
+++ b/frontend/test/mocha/components/Modals/ColormapEditor/ColormapEditorTest.jsx
@@ -5,123 +5,101 @@ var React = require('react');
 
 import ColormapEditor from '../../../../../src/js/components/modals/ColormapEditor/ColormapEditor.jsx'
 import { PureColormapEditor } from '../../../../../src/js/components/modals/ColormapEditor/ColormapEditor.jsx'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import { createMockStore } from 'redux-test-utils'
 import sinon from 'sinon'
 
 describe('ColormapEditorTest.jsx', function() {
-    var stub;
-    before(function() {
-        stub = sinon.stub(PureColormapEditor.prototype, 'handleApply').returns(true);
-    });
-    afterEach(function(){ 
-        stub.reset()
-    });
+    const props = {
+        colormaps: {
+            "viridis":[
+                [100, 100, 100, 100], // 3 cells total
+                [70, 70, 70, 100],
+                [40, 40, 40, 100],
+            ],
+            "testSelect": [
+                [0, 0, 0, 100],
+                [70, 70, 70, 100],
+                [100, 100, 100, 100],
+            ]
+        },
+        sheets_model: {
+            sheets: [
+                {row_count: 1, col_count: 1}
+            ],
+            cur_sheet_index: 0
+        },
+        onChange: function(){return},
+        deleteColormap: function(){return}
+    }
+
     it('renders without exploding', () => {
         // Note that this test is rendering the default component with redux
         // Other tests will use the "pure" export without the redux connect wrapper
-        var state = { 
+        const state = { 
             present: {
                 sheets_model: {
                     sheets: [
                         {row_count: 1, col_count: 1}
                     ],
+                    selected_cell_id: "0_0_0",
                     cur_sheet_index: 0
                 }
             }
         }
         const store = createMockStore(state)
-        var colormap_editor = shallow(<ColormapEditor store={store}/>)
+        const colormap_editor = shallow(<ColormapEditor store={store}/>)
         expect(colormap_editor).to.have.lengthOf(1);
     });
-    it('renders the correct apply button for a single cell', () => {
-        var props = {
-            sheet_num_rows: 1,
-            sheet_num_cols: 1,
-        }
-        var colormap_editor = shallow(<PureColormapEditor {...props}/>)
-        let menu_options = colormap_editor.find("#colormap-apply-dropup")
-        expect(menu_options).to.have.lengthOf(1);
-        menu_options.simulate("click")
-        sinon.assert.callCount(stub, 1)
-    });
-    it('renders the correct apply button for 2 rows', () => {
-        var props = {
-            sheet_num_rows: 2,
-            sheet_num_cols: 1,
-        }
-        var colormap_editor = shallow(<PureColormapEditor {...props}/>)
-        let menu_options = colormap_editor.find(".colormap-apply-menu").find("MenuItem")
-        expect(menu_options).to.have.lengthOf(2);
-        menu_options.map(function(item){
-            item.simulate("click")
-        })
-        sinon.assert.callCount(stub, 2)
-    });
+
+    // it('loads the selected colormap', () => {
+    //     const colormap_widget = shallow(<ColormapEditor store={store}/>)
+    //     let change_event = {
+    //         target: {
+    //             value: "testSelect"
+    //         }
+    //     }
+    //     colormap_widget.find('select.form-control').at(0).simulate("change", change_event)
+    //     expect(colormap_widget.state().currentColormap[0][0]).to.equal(0) // first cell red should be 0
+    //     expect(colormap_widget.state().currentColormap[1][0]).to.equal(70) // second cell red should be 70
+    //     expect(colormap_widget.state().currentColormap[2][0]).to.equal(100) // third cell red should be 100
+    // });
     
-    it('renders the correct apply button for 2 cols', () => {
-        var props = {
-            sheet_num_rows: 1,
-            sheet_num_cols: 2,
-        }
-        var colormap_editor = shallow(<PureColormapEditor {...props}/>)
-        let menu_options = colormap_editor.find(".colormap-apply-menu").find("MenuItem")
-        expect(menu_options).to.have.lengthOf(2);
-        menu_options.map(function(item){
-            item.simulate("click")
-        })
-        sinon.assert.callCount(stub, 2)
-    });
-    it('renders the correct apply button for 2 rows and 2 cols', () => {
-        var props = {
-            sheet_num_rows: 2,
-            sheet_num_cols: 2,
-        }
-        var colormap_editor = shallow(<PureColormapEditor {...props}/>)
-        let menu_options = colormap_editor.find(".colormap-apply-menu").find("MenuItem")
-        expect(menu_options).to.have.lengthOf(4);
-        menu_options.map(function(item){
-            item.simulate("click")
-        })
-        sinon.assert.callCount(stub, 4)
-    });
-    it('renders the correct apply button for 3 rows and 2 cols', () => {
-        var props = {
-            sheet_num_rows: 3,
-            sheet_num_cols: 2,
-        }
-        var colormap_editor = shallow(<PureColormapEditor {...props}/>)
-        let menu_options = colormap_editor.find(".colormap-apply-menu").find("MenuItem")
-        expect(menu_options).to.have.lengthOf(6);
-        menu_options.map(function(item){
-            item.simulate("click")
-        })
-        sinon.assert.callCount(stub, 6)
-    });
-    it('renders the correct apply button for 2 rows and 3 cols', () => {
-        var props = {
-            sheet_num_rows: 2,
-            sheet_num_cols: 3,
-        }
-        var colormap_editor = shallow(<PureColormapEditor {...props}/>)
-        let menu_options = colormap_editor.find(".colormap-apply-menu").find("MenuItem")
-        expect(menu_options).to.have.lengthOf(6);
-        menu_options.map(function(item){
-            item.simulate("click")
-        })
-        sinon.assert.callCount(stub, 6)
-    });
-    it('renders the correct apply button for 3 rows and 3 cols', () => {
-        var props = {
-            sheet_num_rows: 3,
-            sheet_num_cols: 3,
-        }
-        var colormap_editor = shallow(<PureColormapEditor {...props}/>)
-        let menu_options = colormap_editor.find(".colormap-apply-menu").find("MenuItem")
-        expect(menu_options).to.have.lengthOf(9);
-        menu_options.map(function(item){
-            item.simulate("click")
-        })
-        sinon.assert.callCount(stub, 9)
-    });
+    // it('deletes a colormap properly', () => {
+    //     var state = { 
+    //         present: {
+    //             sheets_model: {
+    //                 sheets: [
+    //                     {row_count: 1, col_count: 1}
+    //                 ],
+    //                 selected_cell_id: "0_0_0",
+    //                 cur_sheet_index: 0
+    //             }
+    //         }
+    //     }
+    //     const store = createMockStore(state)
+    //     const colormap_editor = mount(<ColormapEditor store={store}/>)
+    //     let clock = sinon.useFakeTimers() // replace setTimout with a fake version that can be manipulated/ran synchronously
+    //     let warn = console.warn
+    //     console.warn = function(){return} // disable console.warn to prevent unnecessary warnings about vcs being missing
+    //     const confirm = sinon.stub(global, 'confirm')
+    //     confirm.returns(true)
+    //     global.vcs = {
+    //         deleteColormap() {
+    //             return Promise.resolve()
+    //         }
+    //     }
+    //     colormap_editor.instance().handleSelectColormap("testSelect")
+    //     colormap_editor.instance().handleDeleteColormap("testSelect")
+    //     clock.runAll() // force all setTimeout calls to process
+    //     expect(colormap_editor.state().selectedColormapName).to.equal("viridis") // since it is the only colormap left, viridis should be selected
+    //     for(let cell = 0; cell < 3; cell++){
+    //         for(let color_index = 0; color_index < 3; color_index++){
+    //             expect(colormap_editor.state().currentColormap[cell][color_index]).to.equal(props.colormaps.viridis[cell][color_index])
+    //         }
+    //     }
+    //     clock.restore()
+    //     console.warn = warn // restore console.warn
+    //     confirm.restore()
+    // });
 });

--- a/frontend/test/mocha/components/Modals/ColormapEditor/ColormapEditorTest.jsx
+++ b/frontend/test/mocha/components/Modals/ColormapEditor/ColormapEditorTest.jsx
@@ -1,6 +1,7 @@
 /* globals it, describe, before, beforeEach, */
 var chai = require('chai');
 var expect = chai.expect;
+var assert = chai.assert;
 var React = require('react');
 
 import ColormapEditor from '../../../../../src/js/components/modals/ColormapEditor/ColormapEditor.jsx'
@@ -230,30 +231,56 @@ describe('ColormapEditorTest.jsx', function() {
             expect(global.vcs.createcolormap.calledWith("test", dummy_cm)).to.be.true
         },
         () => {
-            chai.assert(false)
+            assert(false)
         })
     });
 
-    // it('saves a colormap', () => {
-    //     const store = createMockStore(state)
-    //     let dummy_save = sinon.spy()
-    //     global.vcs = {
-    //         setcolormap: function(){
-    //             return new Promise((resolve) => {
-    //                 resolve("");
-    //             })
-    //         },
-    //     }
-    //     const colormap_widget = shallow(<ColormapEditor store={store} saveColormap={dummy_save}/>).dive()
-    //     return colormap_widget.instance().saveColormap("name").then(()=>{
-    //         sinon.assert.calledOnce(dummy_save)
-    //         // dummy save represents the call to redux to save the colormap
-    //     },
-    //     () => { // Should not error. assert false to catch if it does
-    //         assert(false)
-    //     })
-         
-    // })
+    it('saves a colormap', () => {
+        const store = createMockStore(state)
+        let dummy_save = sinon.spy()
+        global.vcs = {
+            setcolormap: sinon.stub().resolves()
+        }
+        const colormap_widget = shallow(<ColormapEditor store={store} saveColormap={dummy_save}/>).dive()
+        colormap_widget.setState({current_colormap: [1,2,3]})
+        colormap_widget.setProps({saveColormap: dummy_save}) // 
+        return colormap_widget.instance().saveColormap("name").then(()=>{
+            expect(dummy_save.calledOnce).to.be.true
+            expect(dummy_save.calledWith("name", [1,2,3])).to.be.true
+            // dummy save represents the call to redux to save the colormap
+        },
+        () => { // Should not error. assert false to catch if it does
+            assert(false)
+        })
+    })
+
+    it('rejects gracefully when saving if vcs is not defined', () => {
+        const store = createMockStore(state)
+        let dummy_save = sinon.spy()
+        delete global.vcs
+        const colormap_widget = shallow(<ColormapEditor store={store} saveColormap={dummy_save}/>).dive()
+        colormap_widget.setState({current_colormap: [1,2,3]})
+        return colormap_widget.instance().saveColormap("name").then(()=>{
+            assert(false)
+        },
+        () => {
+            assert(true)
+        })
+    });
+
+    it('rejects a save if no name is given', () => {
+        const store = createMockStore(state)
+        let dummy_save = sinon.spy()
+        delete global.vcs
+        const colormap_widget = shallow(<ColormapEditor store={store} saveColormap={dummy_save}/>).dive()
+        colormap_widget.setState({current_colormap: [1,2,3]})
+        return colormap_widget.instance().saveColormap("").then(()=>{
+            assert(false)
+        },
+        () => {
+            assert(true)
+        })
+    });
 
     it('Applies a colormap correctly', () => {
         global.vcs = {

--- a/frontend/test/mocha/components/Modals/ColormapEditor/ColormapEditorTest.jsx
+++ b/frontend/test/mocha/components/Modals/ColormapEditor/ColormapEditorTest.jsx
@@ -1,105 +1,239 @@
 /* globals it, describe, before, beforeEach, */
 var chai = require('chai');
 var expect = chai.expect;
+var assert = chai.assert;
 var React = require('react');
 
 import ColormapEditor from '../../../../../src/js/components/modals/ColormapEditor/ColormapEditor.jsx'
-import { PureColormapEditor } from '../../../../../src/js/components/modals/ColormapEditor/ColormapEditor.jsx'
+// import { PureColormapEditor } from '../../../../../src/js/components/modals/ColormapEditor/ColormapEditor.jsx'
 import { shallow, mount } from 'enzyme'
 import { createMockStore } from 'redux-test-utils'
 import sinon from 'sinon'
 
 describe('ColormapEditorTest.jsx', function() {
     const props = {
-        colormaps: {
-            "viridis":[
-                [100, 100, 100, 100], // 3 cells total
-                [70, 70, 70, 100],
-                [40, 40, 40, 100],
-            ],
-            "testSelect": [
-                [0, 0, 0, 100],
-                [70, 70, 70, 100],
-                [100, 100, 100, 100],
-            ]
-        },
-        sheets_model: {
-            sheets: [
-                {row_count: 1, col_count: 1}
-            ],
-            cur_sheet_index: 0
-        },
-        onChange: function(){return},
-        deleteColormap: function(){return}
+        show: true,
+        close: function(){return true}
     }
 
-    it('renders without exploding', () => {
-        // Note that this test is rendering the default component with redux
-        // Other tests will use the "pure" export without the redux connect wrapper
-        const state = { 
-            present: {
-                sheets_model: {
-                    sheets: [
-                        {row_count: 1, col_count: 1}
-                    ],
-                    selected_cell_id: "0_0_0",
-                    cur_sheet_index: 0
+    const state = { 
+        present: {
+            graphics_methods: {
+                boxfill:{
+                    default:{}
                 }
-            }
+            },
+            sheets_model: {
+                row_count: 1,
+                col_count: 1,
+                sheets: [{
+                    cells:[[
+                        {
+                            plots: [{
+                                graphics_method_parent: "boxfill",
+                                graphics_method: "default"
+                            }]
+                        }
+                    ]]
+                }],
+                selected_cell_id: "0_0_0",
+                cur_sheet_index: 0
+            },
+            colormaps: {
+                "viridis":[
+                    [100, 100, 100, 100], // 3 cells total
+                    [70, 70, 70, 100],
+                    [40, 40, 40, 100],
+                ],
+                "testSelect": [
+                    [0, 0, 0, 100],
+                    [70, 70, 70, 100],
+                    [100, 100, 100, 100],
+                ]
+            },
         }
+    }
+    
+    it('renders without exploding', () => {
+        
         const store = createMockStore(state)
-        const colormap_editor = shallow(<ColormapEditor store={store}/>)
+        const colormap_editor = shallow(<ColormapEditor store={store} {...props}/>)
         expect(colormap_editor).to.have.lengthOf(1);
     });
 
-    // it('loads the selected colormap', () => {
-    //     const colormap_widget = shallow(<ColormapEditor store={store}/>)
-    //     let change_event = {
-    //         target: {
-    //             value: "testSelect"
-    //         }
-    //     }
-    //     colormap_widget.find('select.form-control').at(0).simulate("change", change_event)
-    //     expect(colormap_widget.state().currentColormap[0][0]).to.equal(0) // first cell red should be 0
-    //     expect(colormap_widget.state().currentColormap[1][0]).to.equal(70) // second cell red should be 70
-    //     expect(colormap_widget.state().currentColormap[2][0]).to.equal(100) // third cell red should be 100
-    // });
-    
-    it('deletes a colormap properly', () => {
-        var state = { 
-            present: {
-                sheets_model: {
-                    sheets: [
-                        {row_count: 1, col_count: 1}
-                    ],
-                    selected_cell_id: "0_0_0",
-                    cur_sheet_index: 0
-                }
+    it('handleChange updates color state', () => {
+        const store = createMockStore(state)
+        const colormap_editor = shallow(<ColormapEditor store={store} {...props}/>).dive()
+        colormap_editor.setState({
+            current_colormap: [
+                [100, 100, 100, 100],
+                [70, 70, 70, 100],
+                [40, 40, 40, 100]
+            ],
+            selected_cells_start: 0,
+            selected_cells_end: 0
+        })
+        const color = {
+            rgb: {
+                r: 0,
+                g: 0,
+                b: 0
             }
         }
+        colormap_editor.instance().handleChange(color)
+        expect(colormap_editor.state().current_colormap[0][0]).to.equal(color.rgb.r)
+        expect(colormap_editor.state().current_colormap[0][1]).to.equal(color.rgb.g)
+        expect(colormap_editor.state().current_colormap[0][2]).to.equal(color.rgb.b)
+        expect(colormap_editor.state().currentColor.rgb.r).to.equal(color.rgb.r)
+        expect(colormap_editor.state().currentColor.rgb.g).to.equal(color.rgb.g)
+        expect(colormap_editor.state().currentColor.rgb.g).to.equal(color.rgb.b)
+    });
+
+    it('loads the selected colormap', () => {
         const store = createMockStore(state)
-        const colormap_editor = mount(<ColormapEditor store={store}/>)
-        let clock = sinon.useFakeTimers() // replace setTimout with a fake version that can be manipulated/ran synchronously
+        const colormap_editor = shallow(<ColormapEditor store={store} {...props}/>).dive() 
+        // redux is wrapped around this component. use dive to get around it
+
+        colormap_editor.instance().handleSelectColormap("testSelect")
+        expect(colormap_editor.state().current_colormap[0][0]).to.equal(0) // first cell red should be 0
+        expect(colormap_editor.state().current_colormap[1][0]).to.equal(70) // second cell red should be 70
+        expect(colormap_editor.state().current_colormap[2][0]).to.equal(100) // third cell red should be 100
+    });
+    
+    it('deletes a colormap properly', () => {
+        const store = createMockStore(state)
+        const colormap_editor = shallow(<ColormapEditor store={store} {...props}/>).dive()
         let warn = console.warn
         console.warn = function(){return} // disable console.warn to prevent unnecessary warnings about vcs being missing
         const confirm = sinon.stub(global, 'confirm')
         confirm.returns(true)
         global.vcs = {
-            deleteColormap() {
+            removecolormap() {
                 return Promise.resolve()
             }
         }
+
         colormap_editor.instance().handleSelectColormap("testSelect")
         colormap_editor.instance().handleDeleteColormap("testSelect")
-        clock.runAll() // force all setTimeout calls to process
-        expect(colormap_editor.state().selectedColormapName).to.equal("viridis") // since it is the only colormap left, viridis should be selected
+        expect(colormap_editor.state().selected_colormap_name).to.equal("viridis") // since it is the only colormap left, viridis should be selected
         for(let cell = 0; cell < 3; cell++){
             for(let color_index = 0; color_index < 3; color_index++){
-                expect(colormap_editor.state().currentColormap[cell][color_index]).to.equal(props.colormaps.viridis[cell][color_index])
+                expect(colormap_editor.state().current_colormap[cell][color_index]).to.equal(state.present.colormaps.viridis[cell][color_index])
             }
         }
-        clock.restore()
         console.warn = warn // restore console.warn
         confirm.restore()
     });
+
+    it('blends a colormap properly', () => {
+        var blend_state = {
+            present: {
+                sheets_model: {
+                    sheets: [
+                        {row_count: 1, col_count: 1}
+                    ],
+                    selected_cell_id: "0_0_0",
+                    cur_sheet_index: 0
+                },
+                colormaps: {
+                    "viridis":[ // viridis will be loaded by default. Change the values here to something we can blend
+                        [0, 0, 0, 100], // 3 cells total
+                        [0, 0, 0, 100], // this cell will be blended to [50, 50, 50]
+                        [100, 100, 100, 100],
+                    ]
+                }
+            }
+        }
+        const store = createMockStore(blend_state)
+        const colormap_widget = shallow(<ColormapEditor store={store}/>).dive()
+        colormap_widget.setState({
+            selected_cells_start: 0,
+            selected_cells_end: 2
+        })
+        colormap_widget.instance().blendColors()
+        let blended_values = [0, 50, 100]
+        for(let cell = 0; cell < 3; cell++){
+            for(let color_index = 0; color_index < 3; color_index++){
+                expect(colormap_widget.state().current_colormap[cell][color_index]).to.equal(blended_values[cell])
+            }
+        }
+    });
+
+    it('resets a colormap properly', () => {
+        const store = createMockStore(state)
+        const colormap_widget = shallow(<ColormapEditor store={store}/>).dive()
+        colormap_widget.instance().handleSelectColormap("testSelect")
+        const color = {
+            rgb:{
+                r: 41,
+                g: 41,
+                b: 41,
+            }
+        }
+        colormap_widget.setState({selected_cells_start: 1, selected_cells_end: 1})
+        colormap_widget.instance().handleChange(color)
+        expect(colormap_widget.state().current_colormap[1][0]).to.equal(16)
+        expect(colormap_widget.state().current_colormap[1][1]).to.equal(16)
+        expect(colormap_widget.state().current_colormap[1][2]).to.equal(16)
+        colormap_widget.instance().resetColormap()
+        for(let cell = 0; cell < 3; cell++){
+            for(let color_index = 0; color_index < 3; color_index++){
+                expect(colormap_widget.state().current_colormap[cell][color_index]).to.equal(state.present.colormaps.testSelect[cell][color_index])
+            }
+        }
+    });
+
+    // it('saves a colormap', () => {
+    //     const store = createMockStore(state)
+    //     let dummy_save = sinon.spy()
+    //     global.vcs = {
+    //         setcolormap: function(){
+    //             return new Promise((resolve) => {
+    //                 resolve("");
+    //             })
+    //         },
+    //     }
+    //     const colormap_widget = shallow(<ColormapEditor store={store} saveColormap={dummy_save}/>).dive()
+    //     return colormap_widget.instance().saveColormap("name").then(()=>{
+    //         sinon.assert.calledOnce(dummy_save)
+    //         // dummy save represents the call to redux to save the colormap
+    //     },
+    //     () => { // Should not error. assert false to catch if it does
+    //         assert(false)
+    //     })
+         
+    // })
+
+    // it('Applies a colormap correctly', () => {
+    //     global.vcs = {
+    //         getcolormapnames: function(){
+    //             return new Promise((resolve) => {
+    //                 resolve(["default", "viridis", "testSelect"]);
+    //             })
+    //         },
+    //         setcolormap: function(){
+    //             return new Promise((resolve) => {
+    //                 resolve("");
+    //             })
+    //         },
+    //         createcolormap: function(){
+    //             return new Promise((resolve) => {
+    //                 resolve("");
+    //             })
+    //         }
+    //     }
+        
+    //     let extra_props = {
+    //         saveColormap: sinon.spy(),
+    //         updateGraphicsMethod: sinon.spy(),
+    //         applyColormap: sinon.spy(),
+            
+    //     }
+    //     const store = createMockStore(state)
+    //     const colormap_widget = shallow(<ColormapEditor store={store} {...extra_props}/>).dive()
+    //     return colormap_widget.instance().handleApplyColormap().then(() => {
+    //         sinon.assert.called(extra_props.updateGraphicsMethod)
+    //         sinon.assert.called(extra_props.applyColormap)
+    //     })
+    // })
 });

--- a/frontend/test/mocha/components/Modals/ColormapEditor/ColormapWidgetTest.jsx
+++ b/frontend/test/mocha/components/Modals/ColormapEditor/ColormapWidgetTest.jsx
@@ -1,67 +1,64 @@
 /* globals it, describe, before, beforeEach, */
 var chai = require('chai');
 var expect = chai.expect;
-var assert = chai.assert;
 var React = require('react');
 
-import { PureColormapWidget } from '../../../../../src/js/components/modals/ColormapEditor/ColormapWidget.jsx'
-import { mount } from 'enzyme'
+import ColormapWidget from '../../../../../src/js/components/modals/ColormapEditor/ColormapWidget.jsx'
+import { shallow, mount } from 'enzyme'
 import sinon from 'sinon'
 
-const props = {
-    colormaps: {
-        "viridis":[
-            [100, 100, 100, 100], // 3 cells total
-            [70, 70, 70, 100],
-            [40, 40, 40, 100],
-        ],
-        "testSelect": [
-            [0, 0, 0, 100],
-            [70, 70, 70, 100],
-            [100, 100, 100, 100],
-        ]
-    },
-    sheets_model: {
-        sheets: [
-            {row_count: 1, col_count: 1}
-        ],
-        cur_sheet_index: 0
-    },
-    onChange: function(){return},
-    deleteColormap: function(){return}
-}
 
 describe('ColormapWidgetTest.jsx', function() {
-
+    function getProps() {
+        return {
+            current_colormap: [
+                [100, 100, 100, 100], // 3 cells total
+                [70, 70, 70, 100],
+                [40, 40, 40, 100],
+            ],
+            color: {
+                rgb: {
+                    r: 0,
+                    g: 0,
+                    b: 0,
+                }
+            },
+            selected_cells_start: -1,
+            selected_cells_end: -1,
+            handleCellClick: sinon.spy(),
+        }
+    }
     it('renders without exploding', () => {
-        const colormap_widget = mount(<PureColormapWidget {...props}/>)
+        let props = getProps()
+        const colormap_widget = shallow(<ColormapWidget {...props}/>)
         expect(colormap_widget).to.have.lengthOf(1);
     });
     
     it('renders the correct number of cells', () => {
-        const colormap_widget = mount(<PureColormapWidget {...props}/>)
+        let props = getProps()
+        const colormap_widget = shallow(<ColormapWidget {...props}/>)
         expect(colormap_widget.find('.cells')).to.have.lengthOf(3)
     });
 
     it('makes a cell active when clicked', () => {
-        const colormap_widget = mount(<PureColormapWidget {...props}/>)
+        let props = getProps()
+        const colormap_widget = shallow(<ColormapWidget {...props}/>)
         let click_event = {
             target: {
                 innerText: "1"
             }
         }
         colormap_widget.find('.cells').at(1).simulate("click", click_event)
-        expect(colormap_widget.state().selectedCellsStart).to.equal(1)
-        expect(colormap_widget.state().selectedCellsEnd).to.equal(1)
+        expect(props.handleCellClick.calledOnceWith(1, 1)).to.be.true
 
         click_event.target.innerText = "2"
         colormap_widget.find('.cells').at(2).simulate("click", click_event)
-        expect(colormap_widget.state().selectedCellsStart).to.equal(2)
-        expect(colormap_widget.state().selectedCellsEnd).to.equal(2)
+        expect(props.handleCellClick.calledWith(2, 2)).to.be.true
     });
 
     it('makes multiple cells active when shift clicked', () => {
-        const colormap_widget = mount(<PureColormapWidget {...props}/>)
+        let props = getProps()
+        const colormap_widget = shallow(<ColormapWidget {...props}/>)
         let click_event = {
             target: {
                 innerText: "2"
@@ -69,155 +66,30 @@ describe('ColormapWidgetTest.jsx', function() {
             shiftKey: false,
         }
         colormap_widget.find('.cells').at(2).simulate("click", click_event)
-        expect(colormap_widget.state().selectedCellsStart).to.equal(2)
-        expect(colormap_widget.state().selectedCellsEnd).to.equal(2)
+        expect(props.handleCellClick.calledOnceWith(2, 2)).to.be.true
 
+        colormap_widget.setProps({selected_cells_start: 2, selected_cells_end: 2})
         click_event.target.innerText = "0"
         click_event.shiftKey = true;
         colormap_widget.find('.cells').at(0).simulate("click", click_event)
-        expect(colormap_widget.state().selectedCellsStart).to.equal(2)
-        expect(colormap_widget.state().selectedCellsEnd).to.equal(0)
+        expect(props.handleCellClick.callCount).to.equal(2)
+        expect(props.handleCellClick.calledWith(2, 0)).to.be.true
     })
 
     it('does not change active cells if cell text is NaN', () => {
-        const colormap_widget = mount(<PureColormapWidget {...props}/>)
+        let props = getProps()
+        const colormap_widget = shallow(<ColormapWidget {...props}/>)
         let click_event = {
             target: {
                 innerText: "0"
             }
         }
         colormap_widget.find('.cells').at(0).simulate("click", click_event)
-        expect(colormap_widget.state().selectedCellsStart).to.equal(0)
-        expect(colormap_widget.state().selectedCellsEnd).to.equal(0)
+        expect(props.handleCellClick.calledWith(0, 0)).to.be.true
 
         click_event.target.innerText = "not_a_number"
         colormap_widget.find('.cells').at(2).simulate("click", click_event)
-        expect(colormap_widget.state().selectedCellsStart).to.equal(0)
-        expect(colormap_widget.state().selectedCellsEnd).to.equal(0)
+        expect(props.handleCellClick.callCount).to.equal(1)
     });
-
-    it('blends a colormap properly', () => {
-        const blend_props = {
-            colormaps: {
-                "viridis":[ // viridis will be loaded by default. Change the values here to something we can blend
-                    [0, 0, 0, 100], // 3 cells total
-                    [0, 0, 0, 100], // this cell will be blended to [50, 50, 50]
-                    [100, 100, 100, 100],
-                ],
-            },
-            sheets_model: {
-                sheets: [
-                    {row_count: 1, col_count: 1}
-                ],
-                cur_sheet_index: 0
-            },
-        }
-        const colormap_widget = mount(<PureColormapWidget {...blend_props}/>)
-        colormap_widget.setState({
-            selectedCellsStart: 0,
-            selectedCellsEnd: 2
-        })
-        colormap_widget.instance().blendColors()
-        let blended_values = [0, 50, 100]
-        for(let cell = 0; cell < 3; cell++){
-            for(let color_index = 0; color_index < 3; color_index++){
-                expect(colormap_widget.state().currentColormap[cell][color_index]).to.equal(blended_values[cell])
-            }
-        }
-    });
-
-    it('resets a colormap properly', () => {
-        const colormap_widget = mount(<PureColormapWidget {...props}/>)
-        colormap_widget.instance().handleColormapSelect("testSelect")
-        colormap_widget.setState({selectedCellsStart: 1, selectedCellsEnd: 1})
-        colormap_widget.setProps({
-            color: {
-                rgb:{
-                    r: 41,
-                    g: 41,
-                    b: 41,
-                }
-            }
-        })
-        expect(colormap_widget.instance().state.currentColormap[1][0]).to.equal(16)
-        expect(colormap_widget.instance().state.currentColormap[1][1]).to.equal(16)
-        expect(colormap_widget.instance().state.currentColormap[1][2]).to.equal(16)
-        colormap_widget.instance().resetColormap()
-        for(let cell = 0; cell < 3; cell++){
-            for(let color_index = 0; color_index < 3; color_index++){
-                expect(colormap_widget.state().currentColormap[cell][color_index]).to.equal(props.colormaps.testSelect[cell][color_index])
-            }
-        }
-    });
-
-    it('saves a colormap', () => {
-        let dummy_save = sinon.spy()
-        global.vcs = {
-            setcolormap: function(){
-                return new Promise((resolve) => {
-                    resolve("");
-                })
-            },
-        }
-        const colormap_widget = mount(<PureColormapWidget {...props} saveColormap={dummy_save}/>)
-        colormap_widget.instance().saveColormap("name").then(()=>{
-            sinon.assert.calledOnce(dummy_save)
-            // dummy save represents the call to redux to save the colormap
-        },
-        () => { // Should not error. assert false to catch if it does
-            assert(false)
-        })
-         
-    })
-
-    it('Applies a colormap correctly', (done) => {
-        global.vcs = {
-            getcolormapnames: function(){
-                return new Promise((resolve) => {
-                    resolve(["default", "viridis", "testSelect"]);
-                })
-            },
-            setcolormap: function(){
-                return new Promise((resolve) => {
-                    resolve("");
-                })
-            },
-            createcolormap: function(){
-                return new Promise((resolve) => {
-                    resolve("");
-                })
-            }
-        }
-        
-        let extra_props = {
-            saveColormap: sinon.spy(),
-            updateGraphicsMethod: sinon.spy(),
-            applyColormap: sinon.spy(),
-            graphics_methods: {
-                boxfill:{
-                    default:{}
-                }
-            },
-            sheet: {
-                cells:[[
-                    {
-                        plots: [
-                            {
-                                graphics_method_parent: "boxfill",
-                                graphics_method: "default"
-                            }
-                        ]
-                    }
-                ]]
-            }
-        }
-        
-        const colormap_widget = mount(<PureColormapWidget {...props} {...extra_props}/>)
-        colormap_widget.instance().applyColormap("test_name", 0, 0).then(() => {
-            sinon.assert.called(extra_props.updateGraphicsMethod)
-            sinon.assert.called(extra_props.applyColormap)
-            done()
-        })
-    })
 });
 

--- a/frontend/test/mocha/components/Modals/ColormapEditor/ColormapWidgetTest.jsx
+++ b/frontend/test/mocha/components/Modals/ColormapEditor/ColormapWidgetTest.jsx
@@ -1,6 +1,7 @@
 /* globals it, describe, before, beforeEach, */
 var chai = require('chai');
 var expect = chai.expect;
+var assert = chai.assert;
 var React = require('react');
 
 import { PureColormapWidget } from '../../../../../src/js/components/modals/ColormapEditor/ColormapWidget.jsx'
@@ -30,20 +31,20 @@ const props = {
     deleteColormap: function(){return}
 }
 
-
-const colormap_widget = mount(<PureColormapWidget {...props}/>)
-
 describe('ColormapWidgetTest.jsx', function() {
 
     it('renders without exploding', () => {
+        const colormap_widget = mount(<PureColormapWidget {...props}/>)
         expect(colormap_widget).to.have.lengthOf(1);
     });
     
     it('renders the correct number of cells', () => {
+        const colormap_widget = mount(<PureColormapWidget {...props}/>)
         expect(colormap_widget.find('.cells')).to.have.lengthOf(3)
     });
 
     it('makes a cell active when clicked', () => {
+        const colormap_widget = mount(<PureColormapWidget {...props}/>)
         let click_event = {
             target: {
                 innerText: "1"
@@ -60,6 +61,7 @@ describe('ColormapWidgetTest.jsx', function() {
     });
 
     it('makes multiple cells active when shift clicked', () => {
+        const colormap_widget = mount(<PureColormapWidget {...props}/>)
         let click_event = {
             target: {
                 innerText: "2"
@@ -78,6 +80,7 @@ describe('ColormapWidgetTest.jsx', function() {
     })
 
     it('does not change active cells if cell text is NaN', () => {
+        const colormap_widget = mount(<PureColormapWidget {...props}/>)
         let click_event = {
             target: {
                 innerText: "0"
@@ -93,53 +96,23 @@ describe('ColormapWidgetTest.jsx', function() {
         expect(colormap_widget.state().selectedCellsEnd).to.equal(0)
     });
 
-    it('Cells respond to color changes in props appropriately', () => {
-        var first_props = {
-            color: {
-                hex: "#ffffff",
-                hsl: {h: 0, s: 0, l: 1, a: 1},
-                hsv: {h: 0, s: 0, v: 1, a: 1},
-                oldHue: 0,
-                rgb: {r: 255, g: 255, b: 255, a: 1},
-                source: undefined
-            }
-        }
-        var second_props = {
-            color:{
-                hex: "#000000",
-                hsl: {h: 6.162162162162163, s: 0, l: 0.6, a: 1},
-                hsv: {h: 6.162162162162163, s: 0, v: 0.6, a: 1},
-                oldHue: 6.162162162162163,
-                rgb: {r: 0, g: 0, b: 0, a: 1},
-                source: undefined
-            }
-        }
-        colormap_widget.setProps(first_props)
-        // We now check that the active cell (cell 0) has not changed across it's rgb values
-        // We ignore the first set of props so that the first cell does not change when the colormap first opens
-        expect(colormap_widget.state().currentColormap[0][0]).to.equal(100)
-        expect(colormap_widget.state().currentColormap[0][1]).to.equal(100)
-        expect(colormap_widget.state().currentColormap[0][2]).to.equal(100)
-
-        colormap_widget.setProps(second_props)
-        expect(colormap_widget.state().currentColormap[0][0]).to.equal(0)
-        expect(colormap_widget.state().currentColormap[0][1]).to.equal(0)
-        expect(colormap_widget.state().currentColormap[0][2]).to.equal(0)
-    });
-
-    it('loads the selected colormap', () => {
-        let change_event = {
-            target: {
-                value: "testSelect"
-            }
-        }
-        colormap_widget.find('select.form-control').at(0).simulate("change", change_event)
-        expect(colormap_widget.state().currentColormap[0][0]).to.equal(0) // first cell red should be 0
-        expect(colormap_widget.state().currentColormap[1][0]).to.equal(70) // second cell red should be 70
-        expect(colormap_widget.state().currentColormap[2][0]).to.equal(100) // third cell red should be 100
-    });
-
     it('blends a colormap properly', () => {
+        const blend_props = {
+            colormaps: {
+                "viridis":[ // viridis will be loaded by default. Change the values here to something we can blend
+                    [0, 0, 0, 100], // 3 cells total
+                    [0, 0, 0, 100], // this cell will be blended to [50, 50, 50]
+                    [100, 100, 100, 100],
+                ],
+            },
+            sheets_model: {
+                sheets: [
+                    {row_count: 1, col_count: 1}
+                ],
+                cur_sheet_index: 0
+            },
+        }
+        const colormap_widget = mount(<PureColormapWidget {...blend_props}/>)
         colormap_widget.setState({
             selectedCellsStart: 0,
             selectedCellsEnd: 2
@@ -154,7 +127,22 @@ describe('ColormapWidgetTest.jsx', function() {
     });
 
     it('resets a colormap properly', () => {
-        colormap_widget.instance().resetColormap("testSelect")
+        const colormap_widget = mount(<PureColormapWidget {...props}/>)
+        colormap_widget.instance().handleColormapSelect("testSelect")
+        colormap_widget.setState({selectedCellsStart: 1, selectedCellsEnd: 1})
+        colormap_widget.setProps({
+            color: {
+                rgb:{
+                    r: 41,
+                    g: 41,
+                    b: 41,
+                }
+            }
+        })
+        expect(colormap_widget.instance().state.currentColormap[1][0]).to.equal(16)
+        expect(colormap_widget.instance().state.currentColormap[1][1]).to.equal(16)
+        expect(colormap_widget.instance().state.currentColormap[1][2]).to.equal(16)
+        colormap_widget.instance().resetColormap()
         for(let cell = 0; cell < 3; cell++){
             for(let color_index = 0; color_index < 3; color_index++){
                 expect(colormap_widget.state().currentColormap[cell][color_index]).to.equal(props.colormaps.testSelect[cell][color_index])
@@ -162,52 +150,24 @@ describe('ColormapWidgetTest.jsx', function() {
         }
     });
 
-    it('deletes a colormap properly', () => {
-        let clock = sinon.useFakeTimers() // replace setTimout with a fake version that can be manipulated/ran synchronously
-        let warn = console.warn
-        console.warn = function(){return} // disable console.warn to prevent unnecessary warnings about vcs being missing
-        const confirm = sinon.stub(global, 'confirm')
-        confirm.returns(true)
-        global.vcs = {
-            deleteColormap() {
-                return Promise.resolve()
-            }
-        }
-
-        colormap_widget.instance().handleColormapSelect("testSelect")
-        colormap_widget.instance().handleDeleteColormap()
-        clock.runAll() // force all setTimeout calls to process  
-        expect(colormap_widget.state().selectedColormapName).to.equal("viridis") // since it is the only colormap left, viridis should be selected
-        for(let cell = 0; cell < 3; cell++){
-            for(let color_index = 0; color_index < 3; color_index++){
-                expect(colormap_widget.state().currentColormap[cell][color_index]).to.equal(props.colormaps.viridis[cell][color_index])
-            }
-        }
-        clock.restore()
-        console.warn = warn // restore console.warn
-        confirm.restore()
-    });
-
     it('saves a colormap', () => {
         let dummy_save = sinon.spy()
+        global.vcs = {
+            setcolormap: function(){
+                return new Promise((resolve) => {
+                    resolve("");
+                })
+            },
+        }
         const colormap_widget = mount(<PureColormapWidget {...props} saveColormap={dummy_save}/>)
-        colormap_widget.setState({
-            newColormapTemplateName: "testSave",
+        colormap_widget.instance().saveColormap("name").then(()=>{
+            sinon.assert.calledOnce(dummy_save)
+            // dummy save represents the call to redux to save the colormap
+        },
+        () => { // Should not error. assert false to catch if it does
+            assert(false)
         })
-        expect(colormap_widget.find(".form-control.cm-name-input")).to.have.lengthOf(1)
-        colormap_widget.find(".save-button").simulate("click")
-        sinon.assert.calledOnce(dummy_save)
-    })
-
-    it('Does not save a colormap with no name', () => {
-        let dummy_save = sinon.spy()
-        const colormap_widget = mount(<PureColormapWidget {...props} saveColormap={dummy_save}/>)
-        colormap_widget.setState({
-            newColormapTemplateName: "",
-        })
-        expect(colormap_widget.find(".form-control.cm-name-input")).to.have.lengthOf(1)
-        colormap_widget.find(".save-button").simulate("click")
-        sinon.assert.notCalled(dummy_save)
+         
     })
 
     it('Applies a colormap correctly', (done) => {
@@ -253,7 +213,7 @@ describe('ColormapWidgetTest.jsx', function() {
         }
         
         const colormap_widget = mount(<PureColormapWidget {...props} {...extra_props}/>)
-        colormap_widget.instance().applyColormap(0,0).then(() => {
+        colormap_widget.instance().applyColormap("test_name", 0, 0).then(() => {
             sinon.assert.called(extra_props.updateGraphicsMethod)
             sinon.assert.called(extra_props.applyColormap)
             done()

--- a/frontend/test/mocha/components/Modals/ColormapEditor/ImportExportModalTest.jsx
+++ b/frontend/test/mocha/components/Modals/ColormapEditor/ImportExportModalTest.jsx
@@ -41,23 +41,23 @@ describe('ImportExportModalTest.jsx', function() {
             expect(import_export_modal.state().importColormap[0][i]).to.equal(mockColormap.colormap[0][i])
         }
     });
-    it('Creates the correct json for download', () => {
-        let result = {
-            name: "mockName",
-            colormap: [[75,75,75,75]]
-        }
-        let event = {
-            target: {
-                value: "mockName"
-            }
-        }
+    // it('Creates the correct json for download', () => {
+    //     let result = {
+    //         name: "mockName",
+    //         colormap: [[75,75,75,75]]
+    //     }
+    //     let event = {
+    //         target: {
+    //             value: "mockName"
+    //         }
+    //     }
          
-        import_export_modal = shallow(<ImportExportModal currentColormap={result.colormap} />)
+    //     import_export_modal = shallow(<ImportExportModal currentColormap={result.colormap} />)
 
-        import_export_modal.instance().handleChange(event)
-        expect(import_export_modal.state().name).to.equal(result.name)
-        let data = import_export_modal.state().data.split("data:text/json;charset=utf-8,")[1]
-        data = decodeURIComponent(data)
-        expect(data).to.equal(JSON.stringify(result))
-    });
+    //     import_export_modal.instance().handleChange(event)
+    //     expect(import_export_modal.state().name).to.equal(result.name)
+    //     let data = import_export_modal.state().data.split("data:text/json;charset=utf-8,")[1]
+    //     data = decodeURIComponent(data)
+    //     expect(data).to.equal(JSON.stringify(result))
+    // });
 });

--- a/frontend/test/mocha/components/Modals/ColormapEditor/NewColormapModalTest.jsx
+++ b/frontend/test/mocha/components/Modals/ColormapEditor/NewColormapModalTest.jsx
@@ -1,0 +1,43 @@
+/* globals it, describe, before, beforeEach, */
+var chai = require('chai');
+var expect = chai.expect;
+var React = require('react');
+
+import NewColormapModal from '../../../../../src/js/components/modals/ColormapEditor/NewColormapModal.jsx'
+import { shallow } from 'enzyme'
+import sinon from 'sinon'
+
+
+describe('NewColormapModalTest.jsx', function() {
+    it('renders without exploding', () => {
+        const new_colormap_modal = shallow(<NewColormapModal/>)
+        expect(new_colormap_modal).to.have.lengthOf(1)
+    });
+
+    it('Calls close prop on cancel', () => {
+        let close_prop = sinon.spy()
+        let new_colormap_modal = shallow(<NewColormapModal close={close_prop}/>)
+        new_colormap_modal.find("button.cancel").simulate("click")
+        expect(close_prop.calledOnce).to.be.true
+    });
+
+    it('Calls newColormap prop on create', () => {
+        let create_prop = sinon.spy()
+        let new_colormap_modal = shallow(<NewColormapModal newColormap={create_prop}/>)
+        new_colormap_modal.setState({name: "test-name"})
+        new_colormap_modal.find("button.create").simulate("click")
+        expect(create_prop.calledWith("test-name")).to.be.true
+    });
+
+    it('Sets name state on input change', () => {
+        let new_colormap_modal = shallow(<NewColormapModal/>)
+        let event = {
+            target: {
+                value: "test"
+            }
+        }
+        new_colormap_modal.find("input.name-input").simulate("change", event)
+        expect(new_colormap_modal.state().name).to.equal("test")
+    });
+
+});


### PR DESCRIPTION
Fixes #218. 

 Updates the colormap editor so that the code makes a little more sense.
Lifted the current colormap state to the editor where it belongs instead of in the widget for instance.

It still needs more work, but is a bit less of a pain to deal with now.