### PR TITLE
Updates the colormap editor ui

### DIFF
--- a/frontend/src/js/components/modals/ColormapEditor/BasicColorSwatch.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/BasicColorSwatch.jsx
@@ -55,7 +55,7 @@ BasicColorSwatch.defaultProps = {
 
 
 
-BasicColorSwatch.PropTypes = {
+BasicColorSwatch.propTypes = {
     colors: React.PropTypes.arrayOf(React.PropTypes.string),
     onChange: React.PropTypes.func,
 }

--- a/frontend/src/js/components/modals/ColormapEditor/ColorPicker.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/ColorPicker.jsx
@@ -105,7 +105,7 @@ class ColorPicker extends Component {
     }
 }
 
-ColorPicker.PropTypes = {
+ColorPicker.propTypes = {
     color: React.PropTypes.object.isRequired,
     onChange: React.PropTypes.func.isRequired
 }

--- a/frontend/src/js/components/modals/ColormapEditor/ColorPicker.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/ColorPicker.jsx
@@ -27,6 +27,10 @@ class ColorPicker extends Component {
                     flexDirection: "column",
                     justifyContent: "flex-start"
                 },
+                container_inline: {
+                    display: "inline-flex",
+                    width: "100%",
+                },
                 colorPreview: {
                     width: '50px',
                     height: '60px',
@@ -87,17 +91,14 @@ class ColorPicker extends Component {
                         </div>
                     </div>
                 </div>
-                <div>
-                    <div>
-                        <div style={ styles.swatch }>
-                            <div style={ styles.colorPreview } />
-                        </div>
-                        <InputFields
-                            style={styles.inputFields}
-                            {...this.props.color}
-                            onChange={ this.props.onChange }
-                        />
+                <div style={styles.container_inline}>
+                    <div style={ styles.swatch }>
+                        <div style={ styles.colorPreview } />
                     </div>
+                    <InputFields
+                        {...this.props.color}
+                        onChange={ this.props.onChange }
+                    />
                 </div>
             </div>
         )

--- a/frontend/src/js/components/modals/ColormapEditor/ColorPicker.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/ColorPicker.jsx
@@ -22,9 +22,14 @@ class ColorPicker extends Component {
                     display: "flex",
                     justifyContent: "space-between"
                 },
+                container_vertical: {
+                    display: "flex",
+                    flexDirection: "column",
+                    justifyContent: "flex-start"
+                },
                 colorPreview: {
                     width: '50px',
-                    height: '100px',
+                    height: '60px',
                     borderRadius: '2px',
                     background: this.props.color.hex
                 },
@@ -55,10 +60,16 @@ class ColorPicker extends Component {
         return(
             <div>
                 <div style={styles.container}>
-                    <BasicColorSwatch 
-                        {...this.props.color}
-                        onChange={ this.props.onChange }
-                    />
+                    <div style={styles.container_vertical}>
+                        <BasicColorSwatch 
+                            {...this.props.color}
+                            onChange={ this.props.onChange }
+                        />
+                        <CustomColorSwatch
+                            {...this.props.color}
+                            onChange={ this.props.onChange }
+                        />
+                    </div>
                     <div>
                         <div style={styles.saturation}>
                             <Saturation
@@ -76,11 +87,7 @@ class ColorPicker extends Component {
                         </div>
                     </div>
                 </div>
-                <div style={styles.container}>
-                    <CustomColorSwatch
-                        {...this.props.color}
-                        onChange={ this.props.onChange }
-                    />
+                <div>
                     <div>
                         <div style={ styles.swatch }>
                             <div style={ styles.colorPreview } />

--- a/frontend/src/js/components/modals/ColormapEditor/InputFields.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/InputFields.jsx
@@ -44,42 +44,50 @@ class InputFields extends Component{
             container:{
                 display: "flex",
                 flex: "1", // take up any unused width
-                justifyContent: "space-between"
+                justifyContent: "space-evenly",
+                paddingBottom: "2px",
+                marginRight: "50px",
             },
             hex:{
-                display: "inline-flex"
+                display: "inline-flex",
+                marginLeft: "10px",
             },
             rgb:{
-                display: "inline-flex"
+                display: "inline-flex",
+                marginLeft: "10px",
             },
             hsv:{
-                display: "inline-flex"
+                display: "inline-flex",
+                marginLeft: "10px",
             },
             hex_input: {
                 wrap: {
                     display: "flex",
-                    flexDirection: "column-reverse"
+                    flexDirection: "column-reverse",
+                    marginLeft: "5px",
                 },
                 input:{
-                    width: "70px"
+                    width: "70px",
                 },
                 label: {
                     fontSize: '12px',
                     color: '#999',
-                }
+                },
             },
             input_box: {
                 wrap: {
                     display: "flex",
                     flexDirection: "column-reverse",
+                    alignItems: "center",
+                    marginLeft: "5px",
                 },
                 input:{
-                    width: "35px"
+                    width: "35px",
                 },
                 label: {
                     fontSize: '12px',
                     color: '#999',
-                }
+                },
             },
         }
 
@@ -147,7 +155,6 @@ class InputFields extends Component{
                         onChange={(val, e) => {this.handleChange(val, e)}}
                     />
                 </div>
-                
             </div>
         )
     }

--- a/frontend/src/js/components/modals/ColormapEditor/InputFields.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/InputFields.jsx
@@ -43,29 +43,19 @@ class InputFields extends Component{
         const styles = {
             container:{
                 display: "flex",
+                flex: "1", // take up any unused width
                 justifyContent: "space-between"
             },
-            hsv:{
+            hex:{
                 display: "inline-flex"
             },
             rgb:{
                 display: "inline-flex"
             },
-            inputBox: {
-                wrap: {
-                    display: "flex",
-                    flexDirection: "column-reverse",
-                    position: ""
-                },
-                input:{
-                    width: "35px"
-                },
-                label: {
-                    fontSize: '12px',
-                    color: '#999',
-                }
+            hsv:{
+                display: "inline-flex"
             },
-            hex: {
+            hex_input: {
                 wrap: {
                     display: "flex",
                     flexDirection: "column-reverse"
@@ -78,42 +68,57 @@ class InputFields extends Component{
                     color: '#999',
                 }
             },
+            input_box: {
+                wrap: {
+                    display: "flex",
+                    flexDirection: "column-reverse",
+                },
+                input:{
+                    width: "35px"
+                },
+                label: {
+                    fontSize: '12px',
+                    color: '#999',
+                }
+            },
         }
 
         return(
             <div style={styles.container}>
-                <div style={styles.rgb} >
+                <div style={styles.hex}>
                     <EditableInput
                         className="input-box-Hex"
-                        style={ styles.hex }
+                        style={ styles.hex_input }
                         label="Hex"
                         value={ this.props.hex }
                         onChange={(val, e) => {this.handleChange(val, e)}}
                     />
+                </div>
+                <div style={styles.rgb} >
                     <EditableInput
                         className="input-box-Red"
-                        style={ styles.inputBox }
+                        style={ styles.input_box }
                         label="R"
                         value={ this.props.rgb.r }
                         onChange={(val, e) => {this.handleChange(val, e)}}
                     />
                     <EditableInput
                         className="input-box-Green"
-                        style={ styles.inputBox }
+                        style={ styles.input_box }
                         label="G"
                         value={ this.props.rgb.g }
                         onChange={(val, e) => {this.handleChange(val, e)}}
                     />
                     <EditableInput
                         className="input-box-Blue"
-                        style={ styles.inputBox }
+                        style={ styles.input_box }
                         label="B"
                         value={ this.props.rgb.b }
                         onChange={(val, e) => {this.handleChange(val, e)}}
                     />
                     <EditableInput
                         className="input-box-Alpha"
-                        style={ styles.inputBox }
+                        style={ styles.input_box }
                         label="A"
                         value={ this.props.rgb.a }
                         onChange={(val, e) => {this.handleChange(val, e)}}
@@ -122,21 +127,21 @@ class InputFields extends Component{
                 <div style={styles.hsv} >
                     <EditableInput
                         className="input-box-Hue"
-                        style={ styles.inputBox }
+                        style={ styles.input_box }
                         label="H"
                         value={ Math.round(this.props.hsv.h) }
                         onChange={(val, e) => {this.handleChange(val, e)}}
                     />
                     <EditableInput
                         className="input-box-Saturation"
-                        style={ styles.inputBox }
+                        style={ styles.input_box }
                         label="S"
                         value={ Math.round(this.props.hsv.s * 100) }
                         onChange={(val, e) => {this.handleChange(val, e)}}
                     />
                     <EditableInput
                         className="input-box-Value"
-                        style={ styles.inputBox }
+                        style={ styles.input_box }
                         label="V"
                         value={ Math.round(this.props.hsv.v * 100) }
                         onChange={(val, e) => {this.handleChange(val, e)}}

--- a/frontend/src/js/components/modals/ColormapEditor/InputFields.jsx
+++ b/frontend/src/js/components/modals/ColormapEditor/InputFields.jsx
@@ -42,15 +42,21 @@ class InputFields extends Component{
     render(){
         const styles = {
             container:{
-                float: "right"
+                display: "flex",
+                justifyContent: "space-between"
             },
             hsv:{
-                float: "left"
+                display: "inline-flex"
             },
             rgb:{
-                float: "right"
+                display: "inline-flex"
             },
             inputBox: {
+                wrap: {
+                    display: "flex",
+                    flexDirection: "column-reverse",
+                    position: ""
+                },
                 input:{
                     width: "35px"
                 },
@@ -60,6 +66,10 @@ class InputFields extends Component{
                 }
             },
             hex: {
+                wrap: {
+                    display: "flex",
+                    flexDirection: "column-reverse"
+                },
                 input:{
                     width: "70px"
                 },
@@ -72,28 +82,7 @@ class InputFields extends Component{
 
         return(
             <div style={styles.container}>
-                <div style={styles.hsv} >
-                    <EditableInput
-                        className="input-box-Hue"
-                        style={ styles.inputBox }
-                        label="Hue"
-                        value={ Math.round(this.props.hsv.h) }
-                        onChange={(val, e) => {this.handleChange(val, e)}}
-                    />
-                    <EditableInput
-                        className="input-box-Saturation"
-                        style={ styles.inputBox }
-                        label="Saturation"
-                        value={ Math.round(this.props.hsv.s * 100) }
-                        onChange={(val, e) => {this.handleChange(val, e)}}
-                    />
-                    <EditableInput
-                        className="input-box-Value"
-                        style={ styles.inputBox }
-                        label="Value"
-                        value={ Math.round(this.props.hsv.v * 100) }
-                        onChange={(val, e) => {this.handleChange(val, e)}}
-                    />
+                <div style={styles.rgb} >
                     <EditableInput
                         className="input-box-Hex"
                         style={ styles.hex }
@@ -101,37 +90,59 @@ class InputFields extends Component{
                         value={ this.props.hex }
                         onChange={(val, e) => {this.handleChange(val, e)}}
                     />
-                </div>
-                <div style={styles.rgb} >
                     <EditableInput
                         className="input-box-Red"
                         style={ styles.inputBox }
-                        label="Red"
+                        label="R"
                         value={ this.props.rgb.r }
                         onChange={(val, e) => {this.handleChange(val, e)}}
                     />
                     <EditableInput
                         className="input-box-Green"
                         style={ styles.inputBox }
-                        label="Green"
+                        label="G"
                         value={ this.props.rgb.g }
                         onChange={(val, e) => {this.handleChange(val, e)}}
                     />
                     <EditableInput
                         className="input-box-Blue"
                         style={ styles.inputBox }
-                        label="Blue"
+                        label="B"
                         value={ this.props.rgb.b }
                         onChange={(val, e) => {this.handleChange(val, e)}}
                     />
                     <EditableInput
                         className="input-box-Alpha"
                         style={ styles.inputBox }
-                        label="Alpha"
+                        label="A"
                         value={ this.props.rgb.a }
                         onChange={(val, e) => {this.handleChange(val, e)}}
                     />
                 </div>
+                <div style={styles.hsv} >
+                    <EditableInput
+                        className="input-box-Hue"
+                        style={ styles.inputBox }
+                        label="H"
+                        value={ Math.round(this.props.hsv.h) }
+                        onChange={(val, e) => {this.handleChange(val, e)}}
+                    />
+                    <EditableInput
+                        className="input-box-Saturation"
+                        style={ styles.inputBox }
+                        label="S"
+                        value={ Math.round(this.props.hsv.s * 100) }
+                        onChange={(val, e) => {this.handleChange(val, e)}}
+                    />
+                    <EditableInput
+                        className="input-box-Value"
+                        style={ styles.inputBox }
+                        label="V"
+                        value={ Math.round(this.props.hsv.v * 100) }
+                        onChange={(val, e) => {this.handleChange(val, e)}}
+                    />
+                </div>
+                
             </div>
         )
     }


### PR DESCRIPTION
Fixes #234 

Adjusts the size and location of several colormap editor components to reduce wasted space and increase usability.

The "custom colors" widget is moved upward to join the base colors widget.
The input boxes are now laid out horizontally to improve readability.
Removed many floats and older css layout tricks in favor of flexbox. 